### PR TITLE
CLOUD-93253 support ssl for periscope db

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -136,11 +136,11 @@ cloudbreak-conf-db() {
     env-import CB_DB_ENV_SCHEMA "public"
     env-import CB_HBM2DDL_STRATEGY "validate"
 
-    env-import PERISCOPE_DB_USER "postgres"
-    env-import PERISCOPE_DB_NAME "periscopedb"
-    env-import PERISCOPE_DB_PASS ""
-    env-import PERISCOPE_DB_SCHEMA_NAME "public"
-    env-import PERISCOPE_DB_HBM2DDL_STRATEGY "validate"
+    env-import PERISCOPE_DB_ENV_USER "postgres"
+    env-import PERISCOPE_DB_ENV_DB "periscopedb"
+    env-import PERISCOPE_DB_ENV_PASS ""
+    env-import PERISCOPE_DB_ENV_SCHEMA "public"
+    env-import PERISCOPE_HBM2DDL_STRATEGY "validate"
 
     env-import IDENTITY_DB_URL "${COMMON_DB}.service.consul:5432"
     env-import IDENTITY_DB_NAME "uaadb"

--- a/include/compose.bash
+++ b/include/compose.bash
@@ -610,13 +610,13 @@ periscope:
     environment:
         - http_proxy=$CB_HTTP_PROXY
         - https_proxy=$CB_HTTPS_PROXY
-        - PERISCOPE_DB_HBM2DDL_STRATEGY
-        - PERISCOPE_DB_TCP_ADDR
-        - PERISCOPE_DB_TCP_PORT
-        - PERISCOPE_DB_USER
-        - PERISCOPE_DB_PASS
-        - PERISCOPE_DB_NAME
-        - PERISCOPE_DB_SCHEMA_NAME
+        - PERISCOPE_HBM2DDL_STRATEGY
+        - PERISCOPE_DB_PORT_5432_TCP_ADDR
+        - PERISCOPE_DB_PORT_5432_TCP_PORT
+        - PERISCOPE_DB_ENV_USER
+        - PERISCOPE_DB_ENV_PASS
+        - PERISCOPE_DB_ENV_DB
+        - PERISCOPE_DB_ENV_SCHEMA
         - SERVICE_NAME=periscope
           #- SERVICE_CHECK_HTTP=/info
         - 'CB_JAVA_OPTS=$(escape-string-compose-yaml "$CB_JAVA_OPTS" \')'

--- a/include/env.bash
+++ b/include/env.bash
@@ -149,13 +149,13 @@ IDENTITY_DB_PASS - Password for the Identity database authentication
 IDENTITY_DB_URL - Url for the Identity database connection included the port number
 IDENTITY_DB_USER - User for the Identity database authentication
 LOCAL_SMTP_PASSWORD - Default password for the internal mail server
-PERISCOPE_DB_HBM2DDL_STRATEGY - Configures hibernate.hbm2ddl.auto in Autoscale
-PERISCOPE_DB_NAME - Name of the Autoscale database
-PERISCOPE_DB_PASS - Password for the Autoscale database authentication
-PERISCOPE_DB_SCHEMA_NAME - Used schema in the Autoscale database
-PERISCOPE_DB_USER - User for the Autoscale database authentication
-PERISCOPE_DB_TCP_ADDR - Address of the Autoscale database
-PERISCOPE_DB_TCP_PORT - Port number of the Autoscale database
+PERISCOPE_HBM2DDL_STRATEGY - Configures hibernate.hbm2ddl.auto in Autoscale
+PERISCOPE_DB_ENV_DB - Name of the Autoscale database
+PERISCOPE_DB_ENV_PASS - Password for the Autoscale database authentication
+PERISCOPE_DB_ENV_SCHEMA - Used schema in the Autoscale database
+PERISCOPE_DB_ENV_USER - User for the Autoscale database authentication
+PERISCOPE_DB_PORT_5432_TCP_ADDR - Address of the Autoscale database
+PERISCOPE_DB_PORT_5432_TCP_PORT - Port number of the Autoscale database
 PERISCOPE_LOG_LEVEL - Log level of the Autoscale service
 PERISCOPE_SCHEMA_MIGRATION_AUTO - Flag for Autoscale automatic database schema update
 PUBLIC_IP - Ip address or hostname of the public interface


### PR DESCRIPTION
PERISCOPE_DB_HBM2DDL_STRATEGY -> PERISCOPE_HBM2DDL_STRATEGY
PERISCOPE_DB_TCP_ADDR -> PERISCOPE_DB_PORT_5432_TCP_ADDR
PERISCOPE_DB_TCP_PORT -> PERISCOPE_DB_PORT_5432_TCP_PORT
PERISCOPE_DB_USER -> PERISCOPE_DB_ENV_USER
PERISCOPE_DB_PASS -> PERISCOPE_DB_ENV_PASS
PERISCOPE_DB_NAME -> PERISCOPE_DB_ENV_DB
PERISCOPE_DB_SCHEMA_NAME -> PERISCOPE_DB_ENV_SCHEMA

@keyki pls do not merge until https://github.com/hortonworks/cloudbreak/tree/ssl-autoscale-db was not merged