### PR TITLE
BUG-98276 add util command to generate LDAP - OAuth2 mapping script

### DIFF
--- a/include/deployer.bash
+++ b/include/deployer.bash
@@ -663,6 +663,7 @@ main() {
     cmd-export util-local-dev
     cmd-export util-cleanup
     cmd-export util-add-default-user
+    cmd-export util-generate-ldap-mapping
     cmd-export util-get-usage
 
     if [[ "$DEBUG" ]]; then


### PR DESCRIPTION
Until we don't have the admin page to dynamically change these values the process is described in the doc which is really complicated and involves downloading sigil and generating files. With this new util command it is much more simple. The script still must be invoked by the user so he/she has the option to change the mapping.