### PR TITLE
BUG-112706 do not wait for vault when it's not requested

### DIFF
--- a/include/deployer.bash
+++ b/include/deployer.bash
@@ -573,7 +573,9 @@ start-requested-services() {
     fi
 
     compose-up $services
-    init_vault
+    if [[ "$services" == *"vault"* ]]; then
+        init_vault
+    fi
     hdc-cli-downloadable
 }
 


### PR DESCRIPTION
IT runs with 
```
sudo ./cbd start-wait consul registrator identity commondb cloudbreak
```
since vault is not started the check will fail and return with exit code 1