### PR TITLE
BUG-112706 vault needs to pre-started in order to use the generated t…

### DIFF
--- a/include/deployer.bash
+++ b/include/deployer.bash
@@ -573,10 +573,12 @@ start-requested-services() {
         fi
     fi
 
-    compose-up $services
     if [[ "$services" == *"vault"* ]]; then
         init_vault
+        deployer-regenerate
     fi
+
+    compose-up $services
 
     if [[ "$CB_LOCAL_DEV" == "true" ]]; then
         util-local-dev

--- a/include/vault.bash
+++ b/include/vault.bash
@@ -126,12 +126,13 @@ init_vault() {
 
 
         rootToken=$(echo $initLog | jq '.root_token' -r)
-        unsealKeys=$(echo $initLog | jq '.unseal_keys_b64[0]' -r)
+        echo "export VAULT_ROOT_TOKEN=$rootToken" >> $CBD_PROFILE
+        info "$CBD_PROFILE has been updated with the Vault root token"
 
+        unsealKeys=$(echo $initLog | jq '.unseal_keys_b64[0]' -r)
         if [[ "$VAULT_AUTO_UNSEAL" == "true" ]]; then
-            echo "export VAULT_ROOT_TOKEN=$rootToken" >> $CBD_PROFILE
             echo "export VAULT_UNSEAL_KEYS=$unsealKeys" >> $CBD_PROFILE
-            info "$CBD_PROFILE has been updated with the Vault keys"
+            info "$CBD_PROFILE has been updated with the Vault unseal keys"
 
             vault-unseal $unsealKeys
         else
@@ -139,7 +140,6 @@ init_vault() {
             warn "Each time you restart CBD you must unseal Vault with the unseal key."
             warn "You can enable Vault auto unseal by putting the following in your $CBD_PROFILE file"
             warn "export VAULT_AUTO_UNSEAL=true"
-            warn "export VAULT_ROOT_TOKEN=$rootToken"
             warn "export VAULT_UNSEAL_KEYS=$unsealKeys"
         fi
     else

--- a/include/vault.bash
+++ b/include/vault.bash
@@ -79,8 +79,15 @@ ui = true
 EOF
 }
 
+start_vault() {
+    compose-up --no-recreate consul
+    compose-up --no-recreate registrator
+    compose-up --no-recreate vault
+}
+
 init_vault() {
     cloudbreak-config
+    start_vault
 
     local vault_endpoint="http://vault.service.consul:$VAULT_BIND_PORT"
 
@@ -140,10 +147,9 @@ init_vault() {
         if [[ "$VAULT_AUTO_UNSEAL" == "true" ]]; then
             if [[ -z $VAULT_UNSEAL_KEYS ]]; then
                 warn "Vault is initialized, but the unseal keys are not provided in the Profile. Please include them in the VAULT_UNSEAL_KEYS var or manually unseal Vault."
-                _exit 1
+            else
+                vault-unseal $VAULT_UNSEAL_KEYS
             fi
-
-            vault-unseal $VAULT_UNSEAL_KEYS
         else
             warn "Vault auto unseal is disabled so please unseal Vault now in order to use it."
         fi


### PR DESCRIPTION
Cloudbreak needs the vault root token, but to get a root token vault needs to be initialized first and regenerate the compose file in order to pass it to CB