### PR TITLE
BUG-116863 Added root user as prerequisite for bundle collection

### DIFF
--- a/include/export.bash
+++ b/include/export.bash
@@ -1,6 +1,12 @@
 create-bundle() {
     declare desc="Exports and anonymizes logs for fault analysis. Usage: cbd create-bundle [archive_name]"
     declare archivename=$1
+
+    if ! [ $(id -u) = 0 ]; then
+        error "Please run as root, otherwise the tool cannot collect some necessary information for analysis."
+        _exit 1
+    fi
+
     if [[ -z $archivename ]] || [[ "/" == $archivename ]]; then
         archivename="cbd_export_$(date +%s)"
         warn "Invalid archive filename. Generated filename: $archivename"


### PR DESCRIPTION
IPTABLES rules cannot be collected if the user has no root privilages.