### PR TITLE
Additions to help with running CB on Linux.

### DIFF
--- a/include/compose.bash
+++ b/include/compose.bash
@@ -248,7 +248,7 @@ traefik:
     volumes:
         - /var/run/docker.sock:/var/run/docker.sock
         - $CBD_CERT_ROOT_PATH/traefik:/certs/traefik
-        - ./logs/traefik:/opt/traefik/log/
+        - $CBD_LOCAL_DIR/logs/traefik:/opt/traefik/log/
     log_opt:
         max-size: "10M"
         max-file: "5"
@@ -317,7 +317,7 @@ logsink:
     environment:
         - SERVICE_NAME=logsink
     volumes:
-        - ./logs:/tmp
+        - $CBD_LOCAL_DIR/logs:/tmp
     image: hortonworks/socat:1.0.0
     log_opt:
         max-size: "10M"
@@ -351,7 +351,7 @@ logrotate:
         - "LOGROTATE_LOGFILES=/var/log/cloudbreak-deployer/*.log /var/log/cloudbreak-deployer/*/*.log"
         - LOGROTATE_FILESIZE=10M
     volumes:
-        - ./logs:/var/log/cloudbreak-deployer
+        - $CBD_LOCAL_DIR/logs:/var/log/cloudbreak-deployer
     log_opt:
         max-size: "10M"
         max-file: "5"
@@ -387,7 +387,7 @@ vault:
     - SKIP_SETCAP=true
     - SERVICE_NAME=vault
     volumes:
-      - ./$VAULT_CONFIG_FILE:/vault/config/$VAULT_CONFIG_FILE
+      - $CBD_LOCAL_DIR/$VAULT_CONFIG_FILE:/vault/config/$VAULT_CONFIG_FILE
     dns: $PRIVATE_IP
     image: $VAULT_DOCKER_IMAGE:$VAULT_DOCKER_IMAGE_TAG
     restart: on-failure
@@ -412,8 +412,8 @@ identity:
         - IDENTITY_DB_PASS
     dns: $PRIVATE_IP
     volumes:
-      - ./uaa.yml:/uaa/uaa.yml
-      - ./logs/identity:/tomcat/logs/
+      - $CBD_LOCAL_DIR/uaa.yml:/uaa/uaa.yml
+      - $CBD_LOCAL_DIR/logs/identity:/tomcat/logs/
     log_opt:
         max-size: "10M"
         max-file: "5"
@@ -553,8 +553,8 @@ cloudbreak:
     volumes:
         - "$CBD_CERT_ROOT_PATH:/certs"
         - /dev/urandom:/dev/random
-        - ./logs/cloudbreak:/cloudbreak-log
-        - ./etc/:/etc/cloudbreak
+        - $CBD_LOCAL_DIR/logs/cloudbreak:/cloudbreak-log
+        - $CBD_LOCAL_DIR/etc/:/etc/cloudbreak
     dns: $PRIVATE_IP
     links:
         - consul
@@ -660,7 +660,7 @@ periscope:
     dns: $PRIVATE_IP
     volumes:
         - "$CBD_CERT_ROOT_PATH:/certs"
-        - ./logs/autoscale:/autoscale-log
+        - $CBD_LOCAL_DIR/logs/autoscale:/autoscale-log
         - /dev/urandom:/dev/random
     log_opt:
         max-size: "10M"

--- a/include/deployer.bash
+++ b/include/deployer.bash
@@ -422,14 +422,14 @@ network-doctor() {
     fi
 
     echo-n "ping 8.8.8.8 in container: "
-    if docker --rm --name=cbreak_doctor_gdns run --label cbreak.sidekick=true alpine sh -c 'ping -c 1 -W 1 8.8.8.8' &> /dev/null; then
+    if docker run --rm --name=cbreak_doctor_gdns --label cbreak.sidekick=true alpine sh -c 'ping -c 1 -W 1 8.8.8.8' &> /dev/null; then
         info "OK"
     else
         error
     fi
 
     echo-n "ping github.com in container: "
-    if docker --rm --name=cbreak_doctor_github run --label cbreak.sidekick=true alpine sh -c 'ping -c 1 -W 1 github.com' &> /dev/null; then
+    if docker run --rm --name=cbreak_doctor_github --label cbreak.sidekick=true alpine sh -c 'ping -c 1 -W 1 github.com' &> /dev/null; then
         info "OK"
     else
         error

--- a/include/env.bash
+++ b/include/env.bash
@@ -108,6 +108,7 @@ CB_SMARTSENSE_ID - SmartSense subscription ID
 CB_TEMPLATE_DEFAULTS - Comma separated list of the default templates what Cloudbreak initialize in database
 CB_UI_MAX_WAIT - Wait timeout for `cbd start-wait` command
 CB_LOCAL_DEV - If set true then Cloudbreak and Periscope containers will not be created
+CBD_LOCAL_DIR - The location of the cbd-local directory. Defaults to `pwd`.
 CERT_VALIDATION - Enables cert validation in Cloudbreak and Autoscale
 COMMON_DB - Name of the database container
 COMMON_DB_VOL - Name of the database volume


### PR DESCRIPTION
This stems mostly from the fact that, on a docker-machine, /home on the host machine maps to /hosthome, which seems to violate a lot of what cbd assumes. This allows for users to specify a CBD_LOCAL_DIR manually, which can skirt around a lot of these issues.