### PR TITLE
CB-716 gateway should redirect to /environments by default

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -200,10 +200,12 @@ cloudbreak-conf-defaults() {
     if [[ "$CAAS_MOCK" == "true" ]]; then
         env-import ULUWATU_FRONTEND_RULE "PathPrefix:/"
         env-import CAAS_URL $(service-url auth-mock "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "" "8080" "10080")
+        env-import GATEWAY_DEFAULT_REDIRECT_PATH "/environments"
         if [[ "$UMS_ENABLED" == "true" ]]; then
             env-import UMS_HOST $(service-url auth-mock "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "" "" "")
         fi
     else
+        env-import GATEWAY_DEFAULT_REDIRECT_PATH "/cloud"
         env-import CAAS_URL $(service-url caas-api "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "" "8080" "10080")
         if [[ "$UMS_ENABLED" == "true" ]]; then
             env-import UMS_HOST $(service-url caas-api "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "" "" "")

--- a/templates/compose-core-gateway.tmpl
+++ b/templates/compose-core-gateway.tmpl
@@ -16,6 +16,7 @@
         - GATEWAY_UPSTREAM_PORT=80
         - GATEWAY_UNAUTHENTICATED_PATHS=pathPrefix:/auth,pathPrefix:/idp,pathPrefix:/oidc,pathPrefix:/caas,!pathPrefix:/caas/api,pathPrefix:/core,!pathPrefix:/core/api,pathPrefix:/cloud/cb/info
         - UMS_HOST={{{get . "UMS_HOST"}}}
+        - GATEWAY_DEFAULT_REDIRECT_PATH={{{get . "GATEWAY_DEFAULT_REDIRECT_PATH"}}}
 
     dev-gateway:
         image: abiosoft/caddy:no-stats


### PR DESCRIPTION
- in case of mocked cb only environment