### PR TITLE
Fix cloudbreak-environment port expose

### DIFF
--- a/templates/compose-environment.tmpl
+++ b/templates/compose-environment.tmpl
@@ -27,7 +27,7 @@
             - traefik.backend=environment-backend
             - traefik.frontend.priority=10
         ports:
-            - 8087:8080
+            - 8088:8080
         volumes:
             - "{{{get . "CBD_CERT_ROOT_PATH"}}}:/certs"
             - /dev/urandom:/dev/random


### PR DESCRIPTION
Port 8087 has already taken by cloudbreak-redbeams container

please review @keyki @gregito 