### PR TITLE
CB-1284 fix for invalid volume mount in the environment service compose

### DIFF
--- a/templates/compose-environment.tmpl
+++ b/templates/compose-environment.tmpl
@@ -32,7 +32,7 @@
             - "{{{get . "CBD_CERT_ROOT_PATH"}}}:/certs"
             - /dev/urandom:/dev/random
             - ./logs/environment:/environment-log
-            - ./etc/:/etc/environment
+            - ./etc/:/etc/environment-service
         networks:
         - {{{get . "DOCKER_NETWORK_NAME"}}}
         logging:


### PR DESCRIPTION
the `/etc/environment` is an already existing file in the base linux container which made invalid volume mount for the environment service