### PR TITLE
CB-910. Vault is not initialized.

### DIFF
--- a/include/deployer.bash
+++ b/include/deployer.bash
@@ -607,7 +607,7 @@ start-requested-services() {
         fi
     fi
 
-    if [[ "$services" == *"vault"* ]]; then
+    if [[ -z "$services" || "$services" == *"vault"* ]]; then
         init_vault
     fi
 


### PR DESCRIPTION
When cbd start is invoked with no list of services
(signifying that all service should be started), and
the commondb service has not started by the time it is
checked in deployer.bash, the list of services remains
empty. As a result, the check for whether the vault is
one of the services fails, and the vault is not
initialized.

With these changes, the guard has been updated to
initialize the vault when the list of services is empty.