### PR TITLE
Revert caddy to 1.0.1 version from 1.0.2

### DIFF
--- a/templates/compose-core-gateway.tmpl
+++ b/templates/compose-core-gateway.tmpl
@@ -19,7 +19,7 @@
         - GATEWAY_DEFAULT_REDIRECT_PATH={{{get . "GATEWAY_DEFAULT_REDIRECT_PATH"}}}
 
     dev-gateway:
-        image: abiosoft/caddy:no-stats
+        image: abiosoft/caddy:1.0.1
         environment:
         - GATEWAY_HOST=core-gateway
         networks:


### PR DESCRIPTION
no-stats points to a new 1.0.2 version, if that issue still occurs, merge this