### PR TITLE
Use 1.0.1 caddy version with no-stats

### DIFF
--- a/templates/compose-core-gateway.tmpl
+++ b/templates/compose-core-gateway.tmpl
@@ -19,7 +19,7 @@
         - GATEWAY_DEFAULT_REDIRECT_PATH={{{get . "GATEWAY_DEFAULT_REDIRECT_PATH"}}}
 
     dev-gateway:
-        image: abiosoft/caddy:1.0.1
+        image: abiosoft/caddy:1.0.1-no-stats
         environment:
         - GATEWAY_HOST=core-gateway
         networks:


### PR DESCRIPTION
1.0.1 seems slow, probably no-stats version pointed to 1.0.1-no-stats before