### PR TITLE
CB-2717 Add IDBMMS and Environments2 API Svc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,20 @@ update-container-versions:
 	sed -i "0,/DOCKER_TAG_CLOUDBREAK/  s/DOCKER_TAG_CLOUDBREAK .*/DOCKER_TAG_CLOUDBREAK $(CB_VERSION)/" include/cloudbreak.bash
 	sed -i "0,/DOCKER_TAG_ULUWATU/ s/DOCKER_TAG_ULUWATU .*/DOCKER_TAG_ULUWATU $(CB_VERSION)/" include/cloudbreak.bash
 
+update-container-versions-cdpcp:
+	sed -i "0,/DOCKER_TAG_IDBMMS/ s/DOCKER_TAG_IDBMMS .*/DOCKER_TAG_IDBMMS $(CDPCP_VERSION)/" include/cloudbreak.bash
+	sed -i "0,/DOCKER_TAG_ENVIRONMENTS2_API/ s/DOCKER_TAG_ENVIRONMENTS2_API .*/DOCKER_TAG_ENVIRONMENTS2_API $(CDPCP_VERSION)/" include/cloudbreak.bash
+
 push-container-versions: update-container-versions
 	git add include/cloudbreak.bash
 	git commit -m "Updated container versions to $(CB_VERSION)"
 	git tag $(CB_VERSION)
+	git push origin HEAD:$(GIT_BRANCH) --tags
+
+push-container-versions-cdpcp: update-container-versions-cdpcp
+	git add include/cloudbreak.bash
+	git commit -m "Updated CDPCP container versions to $(CDPCP_VERSION)"
+	git tag $(CDPCP_VERSION)
 	git push origin HEAD:$(GIT_BRANCH) --tags
 
 build: bindata ## Creates linux an osx binaries in "build/$OS"

--- a/compose.go
+++ b/compose.go
@@ -49,6 +49,8 @@ func GenerateComposeYaml(args []string) {
 	insertIntoTemplateIfNotLocal(t, localDevList, "periscope")
 	insertIntoTemplateIfNotLocal(t, localDevList, "redbeams")
 	insertIntoTemplateIfNotLocal(t, localDevList, "freeipa")
+	insertIntoTemplateIfNotLocal(t, localDevList, "idbmms")
+	insertIntoTemplateIfNotLocal(t, localDevList, "environments2-api")
 
 	t.Execute(os.Stdout, dataMap)
 }

--- a/deployer.go
+++ b/deployer.go
@@ -74,6 +74,8 @@ func main() {
 		"service-url":           ServiceURL,
 		"generate-traefik-toml": GenerateTraefikToml,
 		"generate-caddy-file":   GenerateCaddyFile,
+		"host-from-url":         HostFromURL,
+		"port-from-url":         PortFromURL,
 	}, []string{
 		"include/circle.bash",
 		"include/cloudbreak.bash",

--- a/functions.go
+++ b/functions.go
@@ -8,6 +8,7 @@ import (
 	"hash"
 	"io"
 	"os"
+	"regexp"
 	"strings"
 	"text/template"
 
@@ -113,4 +114,23 @@ func GenerateCaddyFile(args []string) {
 	t := template.Must(template.New("caddy").Delims("{{{", "}}}").Parse(string(tmpl)))
 
 	t.Execute(os.Stdout, params)
+}
+
+func HostFromURL(args []string) {
+	HostOrPortFromURL(args, 1)
+}
+
+func PortFromURL(args []string) {
+	HostOrPortFromURL(args, 2)
+}
+
+func HostOrPortFromURL(args []string, component int) {
+	url := args[0]
+	pattern := regexp.MustCompile(`(?:[^:]+://)?([^:]+):([0-9]+)(?:/.*)?`)
+	submatch := pattern.FindStringSubmatch(url)
+	if submatch == nil {
+		fatal("Can't parse URL '" + url + "'")
+	} else {
+		fmt.Printf("%s", submatch[component])
+	}
 }

--- a/functions_test.go
+++ b/functions_test.go
@@ -64,3 +64,45 @@ func TestGenerateCaddyFileMultiple(t *testing.T) {
 		}
 	}
 }
+
+func TestHostFromURL(t *testing.T) {
+	var testCases = []struct {
+		args   []string
+		result string
+	}{
+		{[]string{"foo.com:1234"}, "foo.com"},
+		{[]string{"foo.com:1234/bar/blah/"}, "foo.com"},
+		{[]string{"http://foo.com:1234"}, "foo.com"},
+		{[]string{"https://foo.com:1234/bar/blah/"}, "foo.com"},
+	}
+
+	for _, c := range testCases {
+		out := catchStdOut(t, func() {
+			HostFromURL(c.args)
+		})
+		if out != c.result {
+			t.Errorf("Host for URL '%s': got '%s', expected '%s'.", c.args, out, c.result)
+		}
+	}
+}
+
+func TestPortFromURL(t *testing.T) {
+	var testCases = []struct {
+		args   []string
+		result string
+	}{
+		{[]string{"foo.com:1234"}, "1234"},
+		{[]string{"foo.com:1234/bar/blah/"}, "1234"},
+		{[]string{"http://foo.com:1234"}, "1234"},
+		{[]string{"https://foo.com:1234/bar/blah/"}, "1234"},
+	}
+
+	for _, c := range testCases {
+		out := catchStdOut(t, func() {
+			PortFromURL(c.args)
+		})
+		if out != c.result {
+			t.Errorf("Host for URL '%s': got '%s', expected '%s'.", c.args, out, c.result)
+		}
+	}
+}

--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -52,6 +52,9 @@ cloudbreak-conf-tags() {
     env-import DOCKER_TAG_FREEIPA 2.13.0-dev.89
     env-import DOCKER_TAG_ULUWATU 2.13.0-dev.89
 
+    env-import DOCKER_TAG_IDBMMS d4f8f7e4106895e3dec7bfd354e4aefb087823c6
+    env-import DOCKER_TAG_ENVIRONMENTS2_API d4f8f7e4106895e3dec7bfd354e4aefb087823c6
+
     env-import DOCKER_TAG_POSTGRES 9.6.1-alpine
     env-import DOCKER_TAG_LOGROTATE 1.0.1
     env-import DOCKER_TAG_CBD_SMARTSENSE 0.13.4
@@ -66,6 +69,9 @@ cloudbreak-conf-tags() {
     env-import DOCKER_IMAGE_CLOUDBREAK_ENVIRONMENT hortonworks/cloudbreak-environment
     env-import DOCKER_IMAGE_CLOUDBREAK_FREEIPA hortonworks/cloudbreak-freeipa
     env-import DOCKER_IMAGE_CBD_SMARTSENSE hortonworks/cbd-smartsense
+
+    env-import DOCKER_IMAGE_IDBMMS docker-private.infra.cloudera.com/cloudera/thunderhead-idbrokermappingmanagement
+    env-import DOCKER_IMAGE_ENVIRONMENTS2_API docker-private.infra.cloudera.com/cloudera/thunderhead-environments2-api
 
     env-import CB_DEFAULT_SUBSCRIPTION_ADDRESS http://uluwatu:3000/notifications
 
@@ -125,6 +131,12 @@ cloudbreak-conf-db() {
     env-import FREEIPA_DB_ENV_PASS ""
     env-import FREEIPA_DB_ENV_SCHEMA "public"
     env-import FREEIPA_HBM2DDL_STRATEGY "validate"
+
+    env-import IDBMMS_DB_ENV_USER "postgres"
+    env-import IDBMMS_DB_ENV_DB "idbmmsdb"
+    env-import IDBMMS_DB_ENV_PASS ""
+    env-import IDBMMS_DB_PORT_5432_TCP_ADDR "$COMMON_DB"
+    env-import IDBMMS_DB_PORT_5432_TCP_PORT "5432"
 
     env-import VAULT_DB_SCHEMA "vault"
 }
@@ -193,6 +205,20 @@ cloudbreak-conf-defaults() {
     env-import FREEIPA_URL $(service-url freeipa "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "http://" "8090" "8080")
     env-import CLUSTER_PROXY_URL $(service-url cluster-proxy "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "http://" "10081" "8080")
     env-import JAEGER_HOST "$BRIDGE_ADDRESS"
+
+    env-import ENVIRONMENT_HOST $(host-from-url "$ENVIRONMENT_URL")
+    env-import FREEIPA_HOST $(host-from-url "$FREEIPA_URL")
+
+    env-import IDBMMS_URL $(service-url idbmms "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "" "8990" "8982")
+    env-import IDBMMS_HOST $(host-from-url "$IDBMMS_URL")
+    env-import ENVIRONMENTS2_API_URL $(service-url environments2-api "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "http://" "8984" "8982")
+
+    env-import ENVIRONMENT_PORT $(port-from-url "$ENVIRONMENT_URL")
+    env-import FREEIPA_PORT $(port-from-url "$FREEIPA_URL")
+
+    env-import IDBMMS_PORT $(port-from-url "$IDBMMS_URL")
+    env-import IDBMMS_HEALTHZ_PORT 8991
+    env-import ENVIRONMENTS2_API_HEALTHZ_PORT 8983
 
     env-import UAA_ULUWATU_SECRET "dummysecret"
 
@@ -340,7 +366,7 @@ generate-toml-file-for-localdev() {
 
 generate-toml-file-for-localdev-force() {
     declare traefikFile=${1:-traefik.toml}
-    generate-traefik-toml "$CLOUDBREAK_URL" "$PERISCOPE_URL" "$DATALAKE_URL" "$ENVIRONMENT_URL" "$REDBEAMS_URL" "$FREEIPA_URL" "http://$CAAS_URL" "$CLUSTER_PROXY_URL" "$CB_LOCAL_DEV_LIST" > "$traefikFile"
+    generate-traefik-toml "$CLOUDBREAK_URL" "$PERISCOPE_URL" "$DATALAKE_URL" "$ENVIRONMENT_URL" "$REDBEAMS_URL" "$FREEIPA_URL" "http://$CAAS_URL" "$CLUSTER_PROXY_URL" "$ENVIRONMENTS2_API_URL" "$CB_LOCAL_DEV_LIST" > "$traefikFile"
 }
 
 generate-traefik-check-diff() {

--- a/include/compose.bash
+++ b/include/compose.bash
@@ -64,6 +64,8 @@ compose-kill() {
     docker rm -f cbreak_redbeams_1 2> /dev/null || :
     docker rm -f cbreak_environment_1 2> /dev/null || :
     docker rm -f cbreak_freeipa_1 2> /dev/null || :
+    docker rm -f cbreak_idbmms_1 2> /dev/null || :
+    docker rm -f cbreak_environments2-api_1 2> /dev/null || :
 }
 
 util-cleanup() {

--- a/include/db.bash
+++ b/include/db.bash
@@ -16,7 +16,7 @@ db-dump() {
     fi
 
     if [ "$dbName" = "all" ]; then
-        for db in $CB_DB_ENV_DB $PERISCOPE_DB_ENV_DB $VAULT_DB_SCHEMA $DATALAKE_DB_ENV_DB $REDBEAMS_DB_ENV_DB $ENVIRONMENT_DB_ENV_DB $FREEIPA_DB_ENV_DB; do
+        for db in $CB_DB_ENV_DB $PERISCOPE_DB_ENV_DB $VAULT_DB_SCHEMA $DATALAKE_DB_ENV_DB $REDBEAMS_DB_ENV_DB $ENVIRONMENT_DB_ENV_DB $FREEIPA_DB_ENV_DB $IDBMMS_DB_ENV_DB; do
             db-dump-database $db
         done
     else
@@ -51,7 +51,7 @@ db-initialize-databases() {
     migrate-startdb
     db-wait-for-db-cont cbreak_${COMMON_DB}_1
 
-    for db in $CB_DB_ENV_DB $PERISCOPE_DB_ENV_DB $VAULT_DB_SCHEMA $DATALAKE_DB_ENV_DB $REDBEAMS_DB_ENV_DB $ENVIRONMENT_DB_ENV_DB $FREEIPA_DB_ENV_DB; do
+    for db in $CB_DB_ENV_DB $PERISCOPE_DB_ENV_DB $VAULT_DB_SCHEMA $DATALAKE_DB_ENV_DB $REDBEAMS_DB_ENV_DB $ENVIRONMENT_DB_ENV_DB $FREEIPA_DB_ENV_DB $IDBMMS_DB_ENV_DB; do
         db-create-database $db
     done
 

--- a/include/deployer.bash
+++ b/include/deployer.bash
@@ -398,6 +398,8 @@ localdev-doctor() {
     localdev-doctor-service "environment" "8088"
     localdev-doctor-service "freeipa" "8090"
     localdev-doctor-service "cluster-proxy" "10081"
+    localdev-doctor-service "idbmms" "8990"
+    localdev-doctor-service "environments2-api" "8984"
 }
 
 localdev-doctor-service() {

--- a/include/env.bash
+++ b/include/env.bash
@@ -159,6 +159,8 @@ DOCKER_IMAGE_CLOUDBREAK_REDBEAMS - Redbeams Docker image name
 DOCKER_IMAGE_CLOUDBREAK_ENVIRONMENT - Environment Docker image name
 DOCKER_IMAGE_CLOUDBREAK_FREEIPA - FreeIpa Docker image name
 DOCKER_IMAGE_CLOUDBREAK_WEB - Web UI Docker image name
+DOCKER_IMAGE_ENVIRONMENTS2_API - Environments2 API Docker image name
+DOCKER_IMAGE_IDBMMS - IDBMMS Docker image name
 DOCKER_TAG_ALPINE - Alpine container version
 DOCKER_TAG_CBD_SMARTSENSE - SmartSense container version
 DOCKER_TAG_CERT_TOOL - Cert tool container version
@@ -166,11 +168,13 @@ DOCKER_TAG_CLOUDBREAK - Cloudbreak container version
 DOCKER_TAG_CAAS_MOCK - Caas mock image name
 DOCKER_TAG_CONSUL - Consul container version
 DOCKER_TAG_HAVEGED - Haveged container version
+DOCKER_TAG_IDBMMS - IDBMMS container version
 DOCKER_TAG_MIGRATION - Migration container version
 DOCKER_TAG_PERISCOPE - Autoscale container version
 DOCKER_TAG_DATALAKE - Datalake container version
 DOCKER_TAG_REDBEAMS - Redbeams container version
 DOCKER_TAG_ENVIRONMENT - Environment container version
+DOCKER_TAG_ENVIRONMENTS2_API - Environments2 API container version
 DOCKER_TAG_FREEIPA - FreeIpa container version
 DOCKER_TAG_POSTGRES - Postgresql container version
 DOCKER_TAG_LOGROTATE - Logrotate container version
@@ -180,6 +184,11 @@ DOCKER_TAG_ULUWATU - Web UI container version
 DOCKER_STOP_TIMEOUT - Specify a shutdown timeout in seconds for containers
 HTTP_PROXY_HOST - HTTP proxy address
 HTTPS_PROXY_HOST - HTTPS proxy address
+IDBMMS_DB_ENV_DB - Name of the IDBMMS database
+IDBMMS_DB_ENV_PASS - Password for the IDBMMS database authentication
+IDBMMS_DB_ENV_USER - User for the IDBMMS database authentication
+IDBMMS_DB_PORT_5432_TCP_ADDR - Address of the IDBMMS database
+IDBMMS_DB_PORT_5432_TCP_PORT - Port number of the IDBMMS database
 PROXY_PORT - Proxy port
 PROXY_USER - Proxy user (basic auth)
 PROXY_PASSWORD - Proxy password (basic auth)

--- a/include/migrate.bash
+++ b/include/migrate.bash
@@ -113,7 +113,7 @@ migrate-one-db() {
             local docker_image_name=${DOCKER_IMAGE_CLOUDBREAK_FREEIPA}:${DOCKER_TAG_FREEIPA}
             ;;
         *)
-            migrateError "Invalid database service name: $service_name. Supported databases: cbdb, periscopedb, datalakedb, redbeamsdb and environmentdb"
+            migrateError "Invalid database service name: $service_name. Supported databases: cbdb, periscopedb, datalakedb, redbeamsdb, environmentdb and freeipadb"
             return 1
             ;;
     esac
@@ -169,7 +169,7 @@ execute-migration() {
                     fi
                     ;;
                 *)
-                    migrateError "Invalid database service name: $1. Supported databases: cbdb, periscopedb, datalakedb, redbeamsdb and environmentdb"
+                    migrateError "Invalid database service name: $1. Supported databases: cbdb, periscopedb, datalakedb, redbeamsdb, environmentdb and freeipadb"
                     return 1
                     ;;
             esac

--- a/templates/compose-datalake.tmpl
+++ b/templates/compose-datalake.tmpl
@@ -28,6 +28,8 @@
             - "NOTIFICATION_URLS={{{get . "CB_DEFAULT_SUBSCRIPTION_ADDRESS"}}}"
             - "ALTUS_UMS_HOST={{{get . "UMS_HOST"}}}"
             - OPENTRACING_JAEGER_UDP-SENDER_HOST={{{get . "JAEGER_HOST"}}}
+            - "ALTUS_IDBMMS_HOST={{{get . "IDBMMS_HOST"}}}"
+            - "ALTUS_IDBMMS_PORT={{{get . "IDBMMS_PORT"}}}"
         labels:
             - traefik.port=8080
             - traefik.frontend.rule=PathPrefix:/dl/
@@ -41,11 +43,11 @@
             - ./logs/datalake:/datalake-log
             - ./etc/:/etc/datalake
         networks:
-        - {{{get . "DOCKER_NETWORK_NAME"}}}
+            - {{{get . "DOCKER_NETWORK_NAME"}}}
         logging:
             options:
                 max-size: "10M"
                 max-file: "5"
         image: {{{get . "DOCKER_IMAGE_CLOUDBREAK_DATALAKE"}}}:{{{get . "DOCKER_TAG_DATALAKE"}}}
         command: bash
-  {{{end}}}  
+{{{end}}}

--- a/templates/compose-environments2-api.tmpl
+++ b/templates/compose-environments2-api.tmpl
@@ -1,0 +1,30 @@
+{{{define "environments2-api"}}}
+    environments2-api:
+        environment:
+            - http_proxy={{{get . "HTTP_PROXY"}}}
+            - https_proxy={{{get . "HTTPS_PROXY"}}}
+            - "SERVICEDEPENDENCIES_UMSHOST={{{get . "UMS_HOST"}}}"
+            - "SERVICEDEPENDENCIES_UMSPORT={{{get . "UMS_PORT"}}}"
+            - "SERVICEDEPENDENCIES_IDBMMSHOST={{{get . "IDBMMS_HOST"}}}"
+            - "SERVICEDEPENDENCIES_IDBMMSPORT={{{get . "IDBMMS_PORT"}}}"
+            - "SERVICEDEPENDENCIES_CLOUDBREAKENVHOST={{{get . "ENVIRONMENT_HOST"}}}"
+            - "SERVICEDEPENDENCIES_CLOUDBREAKENVPORT={{{get . "ENVIRONMENT_PORT"}}}"
+            - "SERVICEDEPENDENCIES_FMSHOST={{{get . "FREEIPA_HOST"}}}"
+            - "SERVICEDEPENDENCIES_FMSPORT={{{get . "FREEIPA_PORT"}}}"
+            - TELEMETRY_SERVICE_NAME=Environments2Api
+        labels:
+            - traefik.port=8982
+            - traefik.frontend.rule=PathPrefix:/api/v1/environments2/
+            - traefik.backend=environments2-api-backend
+            - traefik.frontend.priority=10
+        ports:
+            - 8984:8982
+            - {{{get . "ENVIRONMENTS2_API_HEALTHZ_PORT"}}}:8983
+        networks:
+            - {{{get . "DOCKER_NETWORK_NAME"}}}
+        logging:
+            options:
+                max-size: "10M"
+                max-file: "5"
+        image: {{{get . "DOCKER_IMAGE_ENVIRONMENTS2_API"}}}:{{{get . "DOCKER_TAG_ENVIRONMENTS2_API"}}}
+{{{end}}}

--- a/templates/compose-idbmms.tmpl
+++ b/templates/compose-idbmms.tmpl
@@ -1,0 +1,26 @@
+{{{define "idbmms"}}}
+    idbmms:
+        environment:
+            - http_proxy={{{get . "HTTP_PROXY"}}}
+            - https_proxy={{{get . "HTTPS_PROXY"}}}
+            - "DB_HOST={{{get . "IDBMMS_DB_PORT_5432_TCP_ADDR"}}}"
+            - "DB_PORT={{{get . "IDBMMS_DB_PORT_5432_TCP_PORT"}}}"
+            - "DB_USER={{{get . "IDBMMS_DB_ENV_USER"}}}"
+            - "DB_PASSWORD={{{get . "IDBMMS_DB_ENV_PASS"}}}"
+            - "DB_NAME={{{get . "IDBMMS_DB_ENV_DB"}}}"
+            - "SERVICEDEPENDENCIES_UMSHOST={{{get . "UMS_HOST"}}}"
+            - "SERVICEDEPENDENCIES_UMSPORT={{{get . "UMS_PORT"}}}"
+            - "SERVICEDEPENDENCIES_CLOUDBREAKENVHOST={{{get . "ENVIRONMENT_HOST"}}}"
+            - "SERVICEDEPENDENCIES_CLOUDBREAKENVPORT={{{get . "ENVIRONMENT_PORT"}}}"
+            - TELEMETRY_SERVICE_NAME=IdBrokerMappingManagement
+        ports:
+            - 8990:8982
+            - {{{get . "IDBMMS_HEALTHZ_PORT"}}}:8983
+        networks:
+            - {{{get . "DOCKER_NETWORK_NAME"}}}
+        logging:
+            options:
+                max-size: "10M"
+                max-file: "5"
+        image: {{{get . "DOCKER_IMAGE_IDBMMS"}}}:{{{get . "DOCKER_TAG_IDBMMS"}}}
+{{{end}}}

--- a/templates/compose-main.tmpl
+++ b/templates/compose-main.tmpl
@@ -162,3 +162,5 @@ services:
 {{{- block "periscope" .}}}{{{end}}}
 {{{- block "redbeams" .}}}{{{end}}}
 {{{- block "freeipa" .}}}{{{end}}}
+{{{- block "idbmms" .}}}{{{end}}}
+{{{- block "environments2-api" .}}}{{{end}}}

--- a/templates/traefik.toml.tmpl
+++ b/templates/traefik.toml.tmpl
@@ -49,6 +49,12 @@
             [backends.cluster-proxy.servers.server0]
             url = "{{{ .ClusterProxyURL }}}"
 {{{- end}}}
+{{{- if isLocal . "environments2-api" }}}
+    [backends.environments2-api]
+        [backends.environments2-api.servers]
+            [backends.environments2-api.servers.server0]
+            url = "{{{ .Environments2ApiURL }}}"
+{{{- end}}}
 
 [frontends]
 {{{- if isLocal . "cloudbreak"}}}
@@ -105,5 +111,12 @@
     backend = "cluster-proxy"
         [frontends.cluster-proxy-frontend.routes.frontendrule]
         rule = "PathPrefix:/cluster-proxy"
+        priority = 100
+{{{- end}}}
+{{{- if isLocal . "environments2-api"}}}
+    [frontends.environments2-api-frontend]
+    backend = "environments2-api"
+        [frontends.environments2-api-frontend.routes.frontendrule]
+        rule = "PathPrefix:/api/v1/environments2/"
         priority = 100
 {{{- end}}}

--- a/traefik.go
+++ b/traefik.go
@@ -9,19 +9,20 @@ import (
 )
 
 type traefikTomlParams struct {
-	CloudbreakURL   string
-	PeriscopeURL    string
-	DatalakeURL     string
-	EnvironmentURL  string
-	RedbeamsURL     string
-	FreeIpaURL      string
-	CaasURL         string
-	ClusterProxyURL string
-	LocalDevList    string
+	CloudbreakURL       string
+	PeriscopeURL        string
+	DatalakeURL         string
+	EnvironmentURL      string
+	RedbeamsURL         string
+	FreeIpaURL          string
+	CaasURL             string
+	ClusterProxyURL     string
+	Environments2ApiURL string
+	LocalDevList        string
 }
 
 func GenerateTraefikToml(args []string) {
-	params := traefikTomlParams{args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8]}
+	params := traefikTomlParams{args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9]}
 	if len(params.LocalDevList) == 0 {
 		fmt.Print("")
 	} else {

--- a/traefik_test.go
+++ b/traefik_test.go
@@ -83,7 +83,7 @@ var expectedMulti string = `[file]
 
 func TestNoLocalService(t *testing.T) {
 	out := catchStdOut(t, func() {
-		GenerateTraefikToml([]string{"cloudbreakURL", "periscopeURL", "datalakeURL", "environmentURL", "redbeamsURL", "freeIpaURL", "caasURL", "clusterProxyURL", ""})
+		GenerateTraefikToml([]string{"cloudbreakURL", "periscopeURL", "datalakeURL", "environmentURL", "redbeamsURL", "freeIpaURL", "caasURL", "clusterProxyURL", "environments2ApiURL", ""})
 	})
 	if len(out) > 0 {
 		t.Errorf("If no local-dev services were defined, traefik.toml should be empty. out:'%s'", out)
@@ -92,7 +92,7 @@ func TestNoLocalService(t *testing.T) {
 
 func TestCloudbreakLocalService(t *testing.T) {
 	out := catchStdOut(t, func() {
-		GenerateTraefikToml([]string{"cloudbreakURL", "periscopeURL", "datalakeURL", "environmentURL", "redbeamsURL", "freeIpaURL", "caasURL", "clusterProxyURL", "cloudbreak"})
+		GenerateTraefikToml([]string{"cloudbreakURL", "periscopeURL", "datalakeURL", "environmentURL", "redbeamsURL", "freeIpaURL", "caasURL", "clusterProxyURL", "environments2ApiURL", "cloudbreak"})
 	})
 	if out != expectedSingle {
 		t.Errorf("If cloudbreak service was defined as local-dev, traefik.toml should contain the cloudbreak service related configs. out:'%s'\nexpected:'%s'", out, expectedSingle)
@@ -101,7 +101,7 @@ func TestCloudbreakLocalService(t *testing.T) {
 
 func TestMultiLocalService(t *testing.T) {
 	out := catchStdOut(t, func() {
-		GenerateTraefikToml([]string{"cloudbreakURL", "periscopeURL", "datalakeURL", "environmentURL", "redbeamsURL", "freeIpaURL", "caasURL", "clusterProxyURL", "cloudbreak,periscope,datalake,environment,redbeams,freeipa"})
+		GenerateTraefikToml([]string{"cloudbreakURL", "periscopeURL", "datalakeURL", "environmentURL", "redbeamsURL", "freeIpaURL", "caasURL", "clusterProxyURL", "environments2ApiURL", "cloudbreak,periscope,datalake,environment,redbeams,freeipa"})
 	})
 	if out != expectedMulti {
 		t.Errorf("If services were defined as local-dev, traefik.toml should contain the defined services. out:'%s'", out)


### PR DESCRIPTION
Re-targeting for master / 2.13.

Notes:
* IDBMMS and Environments2 API Svc are both supported in `CB_LOCAL_DEV_LIST`
* 2 additional Docker containers are started for the new services: `cbreak_environments2-api_1` and `cbreak_idbmms_1`
* Environments2 API Svc can be used with official CDP CLI using `--endpoint-url http://localhost` and without explicitly providing `request_headers` in `~/.cdp/config`
* Both new services work fine with `mock-caas` using the changes of #6091 (2.13.0-dev.78)
* IDBMMS persists into the new DB `idbmmsdb` of `commondb`. Schema migration is not supported, and PostgreSQL schema name is assumed to be `public`. (These features / settings are not supported by IDBMMS.)
* There are two new `make` targets (`update-container-versions-cdpcp` and `push-container-versions-cdpcp`) for updating Docker image tags for the new services as per environment variable `CDPCP_VERSION`
* Documentation (CB `README.md`) update is on the way