### PR TITLE
CB-3400 CBD start should fail when there is no license file

### DIFF
--- a/include/deployer.bash
+++ b/include/deployer.bash
@@ -579,6 +579,12 @@ start-wait-cmd() {
 
 start-requested-services() {
     declare services="$@"
+
+    if [ ! -f "etc/license.txt" ]; then
+      error "License file not found (etc/license.txt). Please provide a license file.";
+      _exit 1
+    fi
+
     cloudbreak-config
 
     deployer-generate


### PR DESCRIPTION
Introduced a check if the license file is not present then the start and restart command will fail.