### PR TITLE
EAR-11495 only open host port 8500 for consul if in dev mode

### DIFF
--- a/include/compose.bash
+++ b/include/compose.bash
@@ -265,7 +265,7 @@ consul:
     ports:
         - "$PRIVATE_IP:53:8600/udp"
         - "8400:8400"
-        - "8500:8500"
+        - "$( if [[ -n "$CB_LOCAL_DEV" ]]; then echo "8500:"; fi )8500"
     hostname: node1
     log_opt:
         max-size: "10M"


### PR DESCRIPTION
- same ear as before, but this customer does not want to have consul 8500 port exposed, only to the host machines
- consul 8500 is only open in dev mode now