### PR TITLE
CB-6445: Add cadence to cloudbreak-deployer for cluster proxy HA

### DIFF
--- a/compose.go
+++ b/compose.go
@@ -42,6 +42,7 @@ func GenerateComposeYaml(args []string) {
 		insertIntoTemplateIfNotLocal(t, localDevList, "core-gateway")
 		insertIntoTemplate(t, "dps")
 	}
+	insertIntoTemplateIfNotLocal(t, localDevList, "cadence")
 	insertIntoTemplateIfNotLocal(t, localDevList, "cluster-proxy")
 	insertIntoTemplateIfNotLocal(t, localDevList, "cloudbreak")
 	insertIntoTemplateIfNotLocal(t, localDevList, "datalake")

--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -58,6 +58,9 @@ cloudbreak-conf-tags() {
     env-import DOCKER_TAG_LOGROTATE 1.0.2
     env-import DOCKER_TAG_CBD_SMARTSENSE 0.13.4
     env-import DOCKER_TAG_CLUSTER_PROXY 2.1.0.0-154
+    env-import DOCKER_TAG_STATSD 1.1.7-2
+    env-import DOCKER_TAG_CADENCE 0.11.0-auto-setup
+    env-import DOCKER_TAG_CADENCE_WEB 1.0.0-b24
 
     env-import DOCKER_IMAGE_CAAS_MOCK docker-private.infra.cloudera.com/cloudera/cloudbreak-mock-caas
     env-import DOCKER_IMAGE_CLOUDBREAK docker-private.infra.cloudera.com/cloudera/cloudbreak
@@ -74,6 +77,9 @@ cloudbreak-conf-tags() {
     env-import DOCKER_IMAGE_ENVIRONMENTS2_API docker-private.infra.cloudera.com/cloudera/thunderhead-environments2-api
     env-import DOCKER_IMAGE_DATALAKE_API docker-private.infra.cloudera.com/cloudera/thunderhead-datalake-api
     env-import DOCKER_IMAGE_CLUSTER_PROXY docker-private.infra.cloudera.com/cloudera/dps-cluster-proxy
+    env-import DOCKER_IMAGE_STATSD graphiteapp/graphite-statsd
+    env-import DOCKER_IMAGE_CADENCE ubercadence/server
+    env-import DOCKER_IMAGE_CADENCE_WEB docker-private.infra.cloudera.com/cloudera/cadence-web
 
     env-import CB_DEFAULT_SUBSCRIPTION_ADDRESS http://uluwatu:3000/notifications
 
@@ -257,6 +263,22 @@ cloudbreak-conf-defaults() {
 
     env-import UMS_PORT "8982"
     env-import CLUSTERPROXY_ENABLED "true"
+
+    env-import STATSD_WEB_PORT "7941"
+    env-import STATSD_CARBON_RECEIVER_PORT "2003"
+    env-import STATSD_PORT "8125"
+    env-import STATSD_ADMIN_PORT "8126"
+    env-import CADENCE_FRONTEND_PORT "7933"
+    env-import CADENCE_HISTORY_PORT "7934"
+    env-import CADENCE_MATCHING_PORT "7935"
+    env-import CADENCE_WORKER_PORT "7939"
+    env-import CADENCE_WEB_PORT "7940"
+    env-import CADENCE_DB_PORT "5432"
+    env-import CADENCE_DB_DRIVER "postgres"
+    env-import CADENCE_DB_ENV_DB "cadencedb"
+    env-import CADENCE_DB_ENV_VISIBILITY_DB "cadence_visitiblitydb"
+    env-import CADENCE_DB_ENV_USER "postgres"
+    env-import CADENCE_DB_ENV_PASS ""
 }
 
 cloudbreak-conf-autscale() {

--- a/templates/compose-cadence.tmpl
+++ b/templates/compose-cadence.tmpl
@@ -1,0 +1,76 @@
+{{{define "cadence"}}}
+    statsd:
+        image: {{{get . "DOCKER_IMAGE_STATSD"}}}:{{{get . "DOCKER_TAG_STATSD"}}}
+        ports:
+            - "{{{get . "STATSD_WEB_PORT"}}}:80"
+            - "{{{get . "STATSD_CARBON_RECEIVER_PORT"}}}:2003"
+            - "{{{get . "STATSD_PORT"}}}:8125"
+            - "{{{get . "STATSD_ADMIN_PORT"}}}:8126"
+    cadence:
+        image: {{{get . "DOCKER_IMAGE_CADENCE"}}}:{{{get . "DOCKER_TAG_CADENCE"}}}
+        ports:
+            - "{{{get . "CADENCE_FRONTEND_PORT"}}}:7933"
+            - "{{{get . "CADENCE_HISTORY_PORT"}}}:7934"
+            - "{{{get . "CADENCE_MATCHING_PORT"}}}:7935"
+            - "{{{get . "CADENCE_WORKER_PORT"}}}:7939"
+        environment:
+            - "POSTGRES_SEEDS={{{get . "COMMON_DB"}}}"
+            - "DB_PORT={{{get . "CADENCE_DB_PORT"}}}"
+            - "DB={{{get . "CADENCE_DB_DRIVER"}}}"
+            - "DBNAME={{{get . "CADENCE_DB_ENV_DB"}}}"
+            - "VISIBILITY_DBNAME={{{get . "CADENCE_DB_ENV_VISIBILITY_DB"}}}"
+            - "POSTGRES_USER={{{get . "CADENCE_DB_ENV_USER"}}}"
+            {{{- if eq (get . "CADENCE_DB_ENV_PASS") "" }}}
+            # If the password is empty then work around a bug in cadence. The password parameter should not be present in the connection string,
+            # otherwise there is no value so the next parameter host=hostname is interpreted as the password and the default host 127.0.0.1 is
+            # used. See these links for more details:
+            # https://github.com/uber/cadence/blob/62ef53da9271263189a234b69aa095d34968d8a9/common/persistence/sql/sqlplugin/postgres/plugin.go#L39
+            # https://github.com/uber/cadence/blob/62ef53da9271263189a234b69aa095d34968d8a9/common/persistence/sql/sqlplugin/postgres/plugin.go#L92
+            #
+            # Upstream fix https://github.com/uber/cadence/pull/3177
+            - "POSTGRES_PWD=;"
+            {{{- else }}}
+            - "POSTGRES_PWD={{{get . "CADENCE_DB_ENV_PASS"}}}"
+            {{{- end }}}
+            - "STATSD_ENDPOINT=statsd:8125"
+            - "DYNAMIC_CONFIG_FILE_PATH=/etc/cadence/config/dynamicconfig/development.yaml"
+        {{{- if eq (get . "CADENCE_DB_ENV_PASS") "" }}}
+        # If the password is empty then work around a bug in cadence. If the password paramter is an empty string,
+        # then the -p argument for the port number is interpreted as the password and the port number is an unknown argument.
+        # The password string is actually two double quotes, not just an empty string.
+        # See https://github.com/uber/cadence/blob/62ef53da9271263189a234b69aa095d34968d8a9/docker/start.sh#L43-L49
+        #
+        # Upstream fix https://github.com/uber/cadence/pull/3177
+        #
+        #
+        # Fix the teardown so that the cadence-server runs as PID 1 and gracefully exits
+        #
+        # Upstream fix https://github.com/uber/cadence/pull/3175
+        # Upstream fix https://github.com/uber/cadence/commit/873f32c04737bec1af42c216be9ae167b1f67cb0
+        entrypoint: ["/bin/bash"]
+        command: -c 'sed -i "s/\$$POSTGRES_PWD/\"\\\\\"\\\\\"\"/;s@bash /start-cadence.sh@exec /start-cadence.sh@" /start.sh; sed -i "s/set -e/set -ex/;s@dockerize.*cadence-server.*@dockerize -template /etc/cadence/config/config_template.yaml:/etc/cadence/config/docker.yaml\nexec cadence-server --root $$CADENCE_HOME --env docker start --services=$$SERVICES@" /start-cadence.sh; exec /docker-entrypoint.sh /start.sh'
+        {{{- else }}}
+        # Fix the teardown so that the cadence-server runs as PID 1 and gracefully exits
+        #
+        # Upstream fix https://github.com/uber/cadence/pull/3175
+        # Upstream fix https://github.com/uber/cadence/commit/873f32c04737bec1af42c216be9ae167b1f67cb0
+        entrypoint: ["/bin/bash"]
+        command: -c 's@bash /start-cadence.sh@exec /start-cadence.sh@" /start.sh; sed -i "s/set -e/set -ex/;s@dockerize.*cadence-server.*@dockerize -template /etc/cadence/config/config_template.yaml:/etc/cadence/config/docker.yaml\nexec cadence-server --root $$CADENCE_HOME --env docker start --services=$$SERVICES@" /start-cadence.sh; exec /docker-entrypoint.sh /start.sh'
+        {{{- end }}}
+        depends_on:
+            - {{{get . "COMMON_DB"}}}
+    cadence-web:
+        image: {{{get . "DOCKER_IMAGE_CADENCE_WEB"}}}:{{{get . "DOCKER_TAG_CADENCE_WEB"}}}
+        environment:
+            - "CADENCE_TCHANNEL_PEERS=cadence:{{{get . "CADENCE_PORT_1"}}}"
+        ports:
+            - "{{{get . "CADENCE_WEB_PORT"}}}:8088"
+        depends_on:
+            - cadence
+        # Without changing the docker image to have an init program, the node program will not gracefully exit.
+        # So don't wait for the timeout and just set the kill signal immediatly.
+        # See https://www.elastic.io/nodejs-as-pid-1-under-docker-images/
+        #
+        # Upstream fix https://github.com/uber/cadence-web/pull/141
+        stop_signal: SIGKILL
+{{{end}}}

--- a/templates/compose-main.tmpl
+++ b/templates/compose-main.tmpl
@@ -156,6 +156,7 @@ services:
                 max-file: "5"
         image: {{{get . "DOCKER_IMAGE_CLOUDBREAK_WEB"}}}:{{{get . "DOCKER_TAG_ULUWATU"}}}
 {{{ block "dps" .}}}{{{end}}}
+{{{ block "cadence" .}}}{{{end}}}
 {{{ block "cluster-proxy" .}}}{{{end}}}
 {{{- block "cloudbreak" .}}}{{{end}}}
 {{{- block "datalake" .}}}{{{end}}}


### PR DESCRIPTION
Cluster proxy HA functionality depends on cadence. Cadence was added
to cloudbreak-deployer.

This was manually tested by running cloudbreak deployer locally.