### PR TITLE
CB-6473 use UAA default secret as Postgres default password

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -103,11 +103,12 @@ cloudbreak-conf-db() {
         env-import CB_DB_ROOT_PATH "/var/lib/boot2docker/cloudbreak"
     fi
 
+    env-import POSTGRES_PASSWORD $UAA_DEFAULT_SECRET
     env-import COMMON_DB commondb
     env-import COMMON_DB_VOL common
     env-import CB_DB_ENV_USER "postgres"
     env-import CB_DB_ENV_DB "cbdb"
-    env-import CB_DB_ENV_PASS ""
+    env-import CB_DB_ENV_PASS $POSTGRES_PASSWORD
     env-import CB_DB_ENV_SCHEMA "public"
     env-import CB_DB_ENV_SSL "false"
     env-import CB_DB_ENV_CERT_FILE ""
@@ -115,7 +116,7 @@ cloudbreak-conf-db() {
 
     env-import PERISCOPE_DB_ENV_USER "postgres"
     env-import PERISCOPE_DB_ENV_DB "periscopedb"
-    env-import PERISCOPE_DB_ENV_PASS ""
+    env-import PERISCOPE_DB_ENV_PASS $POSTGRES_PASSWORD
     env-import PERISCOPE_DB_ENV_SCHEMA "public"
     env-import PERISCOPE_DB_ENV_SSL "false"
     env-import PERISCOPE_DB_ENV_CERT_FILE ""
@@ -124,7 +125,7 @@ cloudbreak-conf-db() {
     env-import IDENTITY_DB_URL "${COMMON_DB}:5432"
     env-import IDENTITY_DB_NAME "uaadb"
     env-import IDENTITY_DB_USER "postgres"
-    env-import IDENTITY_DB_PASS ""
+    env-import IDENTITY_DB_PASS $POSTGRES_PASSWORD
 }
 
 cloudbreak-conf-cert() {

--- a/include/compose.bash
+++ b/include/compose.bash
@@ -364,7 +364,7 @@ services:
             - "5432:5432"
         environment:
         - SERVICE_NAME=$COMMON_DB
-        - POSTGRES_PASSWORD=""
+        - "POSTGRES_PASSWORD=$POSTGRES_PASSWORD"
             #- SERVICE_CHECK_CMD=bash -c 'psql -h 127.0.0.1 -p 5432  -U postgres -c "select 1"'
         volumes:
             - "$COMMON_DB_VOL:/var/lib/postgresql/data"


### PR DESCRIPTION
Tested scenarios:
 - start from scratch
 - start from previous version of cbd(posgtres also) with data
 - downgrade to previous version requires password configs for database dependent services, but it could be done through Profile