### PR TITLE
Add configuration needed for OID sync

### DIFF
--- a/templates/compose-datalake.tmpl
+++ b/templates/compose-datalake.tmpl
@@ -25,6 +25,7 @@
             - DATALAKE_INSTANCE_NODE_ID={{{get . "CB_INSTANCE_NODE_ID"}}}
             - DATALAKE_LOG_LEVEL
             - CB_ENABLEDPLATFORMS
+            - "CLUSTERPROXY_URL={{{get . "CLUSTER_PROXY_URL"}}}"
             - VAULT_ADDR=vault
             - VAULT_PORT={{{get . "VAULT_BIND_PORT"}}}
             - VAULT_ROOT_TOKEN={{{get . "VAULT_ROOT_TOKEN"}}}

--- a/templates/compose-freeipa.tmpl
+++ b/templates/compose-freeipa.tmpl
@@ -44,6 +44,7 @@
             {{{- end}}}
             - CLUSTERPROXY_ENABLED
             - "CLUSTERPROXY_URL={{{get . "CLUSTER_PROXY_URL"}}}"
+            - "FREEIPA_SDX_URL={{{get . "DATALAKE_URL"}}}"
             - ALTUS_MINASSHDMGMT_HOST={{{get . "ALTUS_TUNNEL_MANAGEMENT_HOST"}}}
             - ALTUS_MINASSHDMGMT_PORT={{{get . "ALTUS_TUNNEL_MANAGEMENT_PORT"}}}
             - STATUSCHECKER_ENABLED={{{get . "FREEIPA_STATUSCHECKER_ENABLED"}}}


### PR DESCRIPTION
The freeipa service now includes SDX endpoint and SDX service now includes
cluster proxy url. Both of which are needed for OID sync work.