### PR TITLE
CB-8035: Use cluster proxy 2.1.0.0-316

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -67,8 +67,8 @@ cloudbreak-conf-tags() {
     env-import DOCKER_TAG_POSTGRES 9.6.16-alpine
     env-import DOCKER_TAG_LOGROTATE 1.0.2
     env-import DOCKER_TAG_CBD_SMARTSENSE 0.13.4
-    env-import DOCKER_TAG_CLUSTER_PROXY 2.1.0.0-300
-    env-import DOCKER_TAG_CLUSTER_PROXY_HEALTH_CHECK_WORKER 2.1.0.0-300
+    env-import DOCKER_TAG_CLUSTER_PROXY 2.1.0.0-316
+    env-import DOCKER_TAG_CLUSTER_PROXY_HEALTH_CHECK_WORKER 2.1.0.0-316
     env-import DOCKER_TAG_CADENCE 0.11.0-auto-setup
     env-import DOCKER_TAG_CADENCE_WEB 1.0.0-b24
     env-import DOCKER_TAG_AUDIT 1.0.0-b1241


### PR DESCRIPTION
FreeIPA HA registration with cluser proxy was producing intermittent
errors. Cluster proxy was updated in 2.1.0.0-316 to scale to more
nodes. This updates cbd to use this the fixed version.