### PR TITLE
CB-8085 localhost login and logout redirect need to be updated

### DIFF
--- a/templates/compose-core-gateway.tmpl
+++ b/templates/compose-core-gateway.tmpl
@@ -14,9 +14,10 @@
         - GATEWAY_DPS_JWT_COOKIE_NAME=dps-jwt
         - GATEWAY_UPSTREAM_HOSTNAME=traefik
         - GATEWAY_UPSTREAM_PORT=80
-        - GATEWAY_UNAUTHENTICATED_PATHS=pathPrefix:/auth,pathPrefix:/idp,pathPrefix:/oidc,pathPrefix:/thunderhead,!pathPrefix:/thunderhead/api,pathPrefix:/core,!pathPrefix:/core/api,pathPrefix:/cloud/cb/info,pathPrefix:/cb/info,pathPrefix:/environmentservice/info,pathPrefix:/dl/info,pathPrefix:/freeipa/info
+        - GATEWAY_UNAUTHENTICATED_PATHS=pathPrefix:/idp,pathPrefix:/oidc,pathPrefix:/thunderhead,pathPrefix:/thunderhead/auth,!pathPrefix:/thunderhead/api,pathPrefix:/core,!pathPrefix:/core/api,pathPrefix:/cloud/cb/info,pathPrefix:/cb/info,pathPrefix:/environmentservice/info,pathPrefix:/dl/info,pathPrefix:/freeipa/info
         - UMS_HOST={{{get . "UMS_HOST"}}}
         - GATEWAY_DEFAULT_REDIRECT_PATH={{{get . "GATEWAY_DEFAULT_REDIRECT_PATH"}}}
+        - GATEWAY_REDIRECT_ENDPOINT_PATH=/thunderhead/auth/in
 
     dev-gateway:
         image: abiosoft/caddy:1.0.1-no-stats

--- a/templates/compose-thunderhead-mock.tmpl
+++ b/templates/compose-thunderhead-mock.tmpl
@@ -12,7 +12,7 @@
         - "{{{get . "UMS_PORT"}}}:8982"
         labels:
         - traefik.frontend.priority=100
-        - traefik.frontend.rule=PathPrefix:/thunderhead,/oidc,/idp,/thunderhead
+        - traefik.frontend.rule=PathPrefix:/oidc,/idp,/thunderhead
         - traefik.port=8080
         - traefik.backend=thunderhead-backend
 {{{end}}}


### PR DESCRIPTION
Redirecting address: [https://localhost/auth/in?redirect_uri=https://localhost/environments](https://localhost/auth/in?redirect_uri=https://localhost/environments). However the correct and latest is [https://localhost/thunderhead/auth/in?redirect_uri=https://localhost/environments](https://localhost/thunderhead/auth/in?redirect_uri=https://localhost/environments).

So we fix this at the Cloudbreak Deployer repository.