### PR TITLE
CB-9075 & CB-9047 - added tracing to traefik and uluwatu 

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -457,7 +457,7 @@ generate-toml-file-for-localdev() {
 
 generate-toml-file-for-localdev-force() {
     declare traefikFile=${1:-traefik.toml}
-    generate-traefik-toml "$CLOUDBREAK_URL" "$PERISCOPE_URL" "$DATALAKE_URL" "$ENVIRONMENT_URL" "$REDBEAMS_URL" "$FREEIPA_URL" "http://$THUNDERHEAD_URL" "$CLUSTER_PROXY_URL" "$ENVIRONMENTS2_API_URL" "$DATALAKE_API_URL" "$DISTROX_API_URL" "$CB_LOCAL_DEV_LIST" > "$traefikFile"
+    generate-traefik-toml "$CLOUDBREAK_URL" "$PERISCOPE_URL" "$DATALAKE_URL" "$ENVIRONMENT_URL" "$REDBEAMS_URL" "$FREEIPA_URL" "http://$THUNDERHEAD_URL" "$CLUSTER_PROXY_URL" "$ENVIRONMENTS2_API_URL" "$DATALAKE_API_URL" "$DISTROX_API_URL" "$JAEGER_HOST" "$CB_LOCAL_DEV_LIST" > "$traefikFile"
 }
 
 generate-traefik-check-diff() {

--- a/templates/compose-main.tmpl
+++ b/templates/compose-main.tmpl
@@ -62,12 +62,14 @@ services:
         command: server
 
     jaeger:
-        image: docker-private.infra.cloudera.com/cloudera_thirdparty/jaegertracing/all-in-one:1.13
+        image: docker-private.infra.cloudera.com/cloudera_thirdparty/jaegertracing/all-in-one:1.20
         networks:
             - {{{get . "DOCKER_NETWORK_NAME"}}}
         ports:
-            - "6831:6831/udp"
-            - "16686:16686"
+            - 5778:5778
+            - 6831:6831/udp
+            - 14268:14268
+            - 16686:16686
         deploy:
           resources:
             limits:
@@ -89,6 +91,8 @@ services:
             - "ULU_PERISCOPE_ADDRESS={{{get . "PERISCOPE_URL"}}}"
             - "ULU_FREEIPA_ADDRESS={{{get . "FREEIPA_URL"}}}"
             - 'ULU_SESSION_STORE_SECRET={{{getEscaped . "UAA_ULUWATU_SECRET"}}}'
+            - JAEGER_ENDPOINT=http://{{{get . "JAEGER_HOST"}}}:14268/api/traces
+            - JAEGER_SAMPLER_MANAGER_HOST_PORT=http://{{{get . "JAEGER_HOST"}}}:5778/sampling
             - ULU_SUBSCRIBE_TO_NOTIFICATIONS
             - AWS_INSTANCE_ID
             - AWS_ACCOUNT_ID

--- a/templates/traefik.toml.tmpl
+++ b/templates/traefik.toml.tmpl
@@ -159,3 +159,17 @@
         rule = "PathPrefix:/api/v1/audit/"
         priority = 100
 {{{- end}}}
+
+# Tracing definition
+[tracing]
+  backend = "jaeger"
+  serviceName = "traefik"
+  spanNameLimit = 0
+
+  [tracing.jaeger]
+    localAgentHostPort = "{{{ .JAEGER_HOST }}}:6831"
+    samplingServerURL = "http://{{{ .JAEGER_HOST }}}:5778/sampling"
+    samplingType = "const"
+    samplingParam = 1.0
+    traceContextHeaderName = "uber-trace-id"
+    disableAttemptReconnecting = false

--- a/traefik.go
+++ b/traefik.go
@@ -21,11 +21,12 @@ type traefikTomlParams struct {
 	DatalakeApiURL      string
 	DistroxApiURL       string
 	AuditApiURL         string
+	JAEGER_HOST         string
 	LocalDevList        string
 }
 
 func GenerateTraefikToml(args []string) {
-	params := traefikTomlParams{args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[10], args[11]}
+	params := traefikTomlParams{args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9], args[10], args[10], args[11], args[12]}
 	if len(params.LocalDevList) == 0 {
 		fmt.Print("")
 	} else {

--- a/traefik_test.go
+++ b/traefik_test.go
@@ -18,6 +18,20 @@ var expectedSingle string = `[file]
         [frontends.cloudbreak-frontend.routes.frontendrule]
         rule = "PathPrefix:/cb/"
         priority = 100
+
+# Tracing definition
+[tracing]
+  backend = "jaeger"
+  serviceName = "traefik"
+  spanNameLimit = 0
+
+  [tracing.jaeger]
+    localAgentHostPort = "JAEGER_HOST:6831"
+    samplingServerURL = "http://JAEGER_HOST:5778/sampling"
+    samplingType = "const"
+    samplingParam = 1.0
+    traceContextHeaderName = "uber-trace-id"
+    disableAttemptReconnecting = false
 `
 
 var expectedMulti string = `[file]
@@ -79,11 +93,25 @@ var expectedMulti string = `[file]
         [frontends.freeipa-frontend.routes.frontendrule]
         rule = "PathPrefix:/freeipa/"
         priority = 100
+
+# Tracing definition
+[tracing]
+  backend = "jaeger"
+  serviceName = "traefik"
+  spanNameLimit = 0
+
+  [tracing.jaeger]
+    localAgentHostPort = "JAEGER_HOST:6831"
+    samplingServerURL = "http://JAEGER_HOST:5778/sampling"
+    samplingType = "const"
+    samplingParam = 1.0
+    traceContextHeaderName = "uber-trace-id"
+    disableAttemptReconnecting = false
 `
 
 func TestNoLocalService(t *testing.T) {
 	out := catchStdOut(t, func() {
-		GenerateTraefikToml([]string{"cloudbreakURL", "periscopeURL", "datalakeURL", "environmentURL", "redbeamsURL", "freeIpaURL", "thunderheadMockURL", "clusterProxyURL", "environments2ApiURL", "datalakeApiURL", "distroxApiURL", ""})
+		GenerateTraefikToml([]string{"cloudbreakURL", "periscopeURL", "datalakeURL", "environmentURL", "redbeamsURL", "freeIpaURL", "thunderheadMockURL", "clusterProxyURL", "environments2ApiURL", "datalakeApiURL", "distroxApiURL", "JAEGER_HOST", ""})
 	})
 	if len(out) > 0 {
 		t.Errorf("If no local-dev services were defined, traefik.toml should be empty. out:'%s'", out)
@@ -92,7 +120,7 @@ func TestNoLocalService(t *testing.T) {
 
 func TestCloudbreakLocalService(t *testing.T) {
 	out := catchStdOut(t, func() {
-		GenerateTraefikToml([]string{"cloudbreakURL", "periscopeURL", "datalakeURL", "environmentURL", "redbeamsURL", "freeIpaURL", "thunderheadURL", "clusterProxyURL", "environments2ApiURL", "datalakeApiURL", "distroxApiURL", "cloudbreak"})
+		GenerateTraefikToml([]string{"cloudbreakURL", "periscopeURL", "datalakeURL", "environmentURL", "redbeamsURL", "freeIpaURL", "thunderheadURL", "clusterProxyURL", "environments2ApiURL", "datalakeApiURL", "distroxApiURL", "JAEGER_HOST", "cloudbreak"})
 	})
 	if out != expectedSingle {
 		t.Errorf("If cloudbreak service was defined as local-dev, traefik.toml should contain the cloudbreak service related configs. out:'%s'\nexpected:'%s'", out, expectedSingle)
@@ -101,7 +129,7 @@ func TestCloudbreakLocalService(t *testing.T) {
 
 func TestMultiLocalService(t *testing.T) {
 	out := catchStdOut(t, func() {
-		GenerateTraefikToml([]string{"cloudbreakURL", "periscopeURL", "datalakeURL", "environmentURL", "redbeamsURL", "freeIpaURL", "thunderheadURL", "clusterProxyURL", "environments2ApiURL", "datalakeApiURL", "distroxApiURL", "cloudbreak,periscope,datalake,environment,redbeams,freeipa"})
+		GenerateTraefikToml([]string{"cloudbreakURL", "periscopeURL", "datalakeURL", "environmentURL", "redbeamsURL", "freeIpaURL", "thunderheadURL", "clusterProxyURL", "environments2ApiURL", "datalakeApiURL", "distroxApiURL", "JAEGER_HOST", "cloudbreak,periscope,datalake,environment,redbeams,freeipa"})
 	})
 	if out != expectedMulti {
 		t.Errorf("If services were defined as local-dev, traefik.toml should contain the defined services. out:'%s'", out)


### PR DESCRIPTION
- uluwatu is using the http endpoint because it was unreliable on udp
- 2 new jaeger ports opened
- 5778 for serving configs to traefik
- 14268 http collector endpoint for uluwatu
