### PR TITLE
Revert "Update cluster proxy version to 2.1.0.0-393"

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -67,8 +67,8 @@ cloudbreak-conf-tags() {
 
     env-import DOCKER_TAG_POSTGRES 9.6.16-alpine
     env-import DOCKER_TAG_CBD_SMARTSENSE 0.13.4
-    env-import DOCKER_TAG_CLUSTER_PROXY 2.1.0.0-393
-    env-import DOCKER_TAG_CLUSTER_PROXY_HEALTH_CHECK_WORKER 2.1.0.0-393
+    env-import DOCKER_TAG_CLUSTER_PROXY 2.1.0.0-362
+    env-import DOCKER_TAG_CLUSTER_PROXY_HEALTH_CHECK_WORKER 2.1.0.0-362
     env-import DOCKER_TAG_CADENCE 0.11.0-auto-setup
     env-import DOCKER_TAG_CADENCE_WEB 1.0.0-b24
     env-import DOCKER_TAG_AUDIT 1.0.0-b1898


### PR DESCRIPTION
This reverts commit 3b5efbbef660c09682707c32afe926978f7d0b73.

See CDPAM-1103 for details.