### PR TITLE
CB-9112 thunderhead-mock was not unavailable via https. With this PR …

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -291,7 +291,7 @@ cloudbreak-conf-defaults() {
 
     if [[ "$THUNDERHEAD_MOCK" == "true" ]]; then
         env-import ULUWATU_FRONTEND_RULE "PathPrefix:/"
-        env-import THUNDERHEAD_URL $(service-url thunderhead-mock "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "" "8080" "8080")
+        env-import THUNDERHEAD_URL $(service-url thunderhead-mock "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "" "10080" "10080")
         env-import GATEWAY_DEFAULT_REDIRECT_PATH "/environments"
         if [[ "$UMS_ENABLED" == "true" ]]; then
             env-import UMS_HOST $(service-url thunderhead-mock "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "" "" "")

--- a/templates/traefik.toml.tmpl
+++ b/templates/traefik.toml.tmpl
@@ -73,6 +73,12 @@
             [backends.distrox-api.servers.server0]
             url = "{{{ .DistroxApiURL }}}"
 {{{- end}}}
+{{{- if isLocal . "thunderhead-mock" }}}
+    [backends.thunderhead-mock]
+        [backends.thunderhead-mock.servers]
+            [backends.thunderhead-mock.servers.server0]
+            url = "{{{ .ThunderheadURL }}}"
+{{{- end}}}
 
 [frontends]
 {{{- if isLocal . "cloudbreak"}}}
@@ -157,6 +163,13 @@
     backend = "audit-api"
         [frontends.audit-api-frontend.routes.frontendrule]
         rule = "PathPrefix:/api/v1/audit/"
+        priority = 100
+{{{- end}}}
+{{{- if isLocal . "thunderhead-mock"}}}
+    [frontends.thunderhead-mock-frontend]
+    backend = "thunderhead-mock"
+        [frontends.thunderhead-mock-frontend.routes.frontendrule]
+        rule = "PathPrefix:/thunderhead/"
         priority = 100
 {{{- end}}}
 


### PR DESCRIPTION
…I expose with traefik. Now the Integration test can access the image catalog without port as well and the freeipa is mockable because the https required for the ping