### PR TITLE
CB-9474 - cli throws unrecognised field exception for env cli command generation for response in CloudSubnet

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -60,10 +60,10 @@ cloudbreak-conf-tags() {
     env-import DOCKER_TAG_FREEIPA 2.33.0-b32
     env-import DOCKER_TAG_ULUWATU 2.33.0-b32
 
-    env-import DOCKER_TAG_IDBMMS 1.0.0-b2235
-    env-import DOCKER_TAG_ENVIRONMENTS2_API 1.0.0-b2235
-    env-import DOCKER_TAG_DATALAKE_API 1.0.0-b2235
-    env-import DOCKER_TAG_DISTROX_API 1.0.0-b2235
+    env-import DOCKER_TAG_IDBMMS 1.0.0-b2384
+    env-import DOCKER_TAG_ENVIRONMENTS2_API 1.0.0-b2384
+    env-import DOCKER_TAG_DATALAKE_API 1.0.0-b2384
+    env-import DOCKER_TAG_DISTROX_API 1.0.0-b2384
 
     env-import DOCKER_TAG_POSTGRES 9.6.16-alpine
     env-import DOCKER_TAG_CBD_SMARTSENSE 0.13.4


### PR DESCRIPTION
CB-9474 - cli throws unrecognised field exception for env cli command generation for response in CloudSubnet