### PR TITLE
CB-9874 Make cdp public endpoint service locally debuggable

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -265,6 +265,8 @@ cloudbreak-conf-defaults() {
     env-import MOCK_INFRASTRUCTURE_BIND_PORT 10090
     env-import MOCK_INFRASTRUCTURE_URL $(service-url mock-infrastructure "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "https://" "$MOCK_INFRASTRUCTURE_BIND_PORT" "10090")
 
+    env-import CLOUDBREAK_HOST $(host-from-url "$CLOUDBREAK_URL")
+    env-import PERISCOPE_HOST $(host-from-url "$PERISCOPE_URL")
     env-import ENVIRONMENT_HOST $(host-from-url "$ENVIRONMENT_URL")
     env-import FREEIPA_HOST $(host-from-url "$FREEIPA_URL")
 
@@ -274,8 +276,14 @@ cloudbreak-conf-defaults() {
     env-import IDBMMS_URL $(service-url idbmms "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "" "8990" "8982")
     env-import IDBMMS_HOST $(host-from-url "$IDBMMS_URL")
     env-import ENVIRONMENTS2_API_URL $(service-url environments2-api "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "http://" "8984" "8982")
+    env-import ENVIRONMENTS2_DEBUG false
+    env-import ENVIRONMENTS2_DEBUG_PORT 5001
     env-import DATALAKE_API_URL $(service-url datalake-api "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "http://" "8986" "8984")
+    env-import DATALAKE_API_DEBUG false
+    env-import DATALAKE_API_DEBUG_PORT 5002
     env-import DISTROX_API_URL $(service-url distrox-api "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "http://" "8988" "8992")
+    env-import DISTROX_API_DEBUG false
+    env-import DISTROX_API_DEBUG_PORT 5003
     env-import AUDIT_API_URL $(service-url audit-api "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "http://" "8972" "8982")
 
     env-import ENVIRONMENT_PORT $(port-from-url "$ENVIRONMENT_URL")

--- a/templates/compose-datalake-api.tmpl
+++ b/templates/compose-datalake-api.tmpl
@@ -10,6 +10,7 @@
             - "SERVICEDEPENDENCIES_CLUSTERHEALTHHOST=localhost"
             - "SERVICEDEPENDENCIES_CLUSTERHEALTHPORT=8986"
             - TELEMETRY_SERVICE_NAME=DatalakeApi
+            - DEBUG={{{get . "DATALAKE_API_DEBUG"}}}
         {{{- if get . "DATALAKE_API_TARGET_PATH"}}}
         volumes:
         - {{{get . "DATALAKE_API_TARGET_PATH"}}}/dependency-hard-links:/thunderhead-datalake-api-service/lib
@@ -21,6 +22,7 @@
             - traefik.backend=datalake-api-backend
             - traefik.frontend.priority=10
         ports:
+            - {{{get . "DATALAKE_API_DEBUG_PORT"}}}:5005
             - 8986:8982
             - {{{get . "DATALAKE_API_HEALTHZ_PORT"}}}:8983
         networks:

--- a/templates/compose-distrox-api.tmpl
+++ b/templates/compose-distrox-api.tmpl
@@ -5,13 +5,14 @@
             - https_proxy={{{get . "HTTPS_PROXY"}}}
             - "SERVICEDEPENDENCIES_UMSHOST={{{get . "UMS_HOST"}}}"
             - "SERVICEDEPENDENCIES_UMSPORT={{{get . "UMS_PORT"}}}"
-            - "SERVICEDEPENDENCIES_CLOUDBREAKHOST={{{get . "CB_HOST_ADDRESS"}}}"
+            - "SERVICEDEPENDENCIES_CLOUDBREAKHOST={{{get . "CLOUDBREAK_HOST"}}}"
             - "SERVICEDEPENDENCIES_CLOUDBREAKPORT={{{get . "CB_PORT"}}}"
-            - "SERVICEDEPENDENCIES_PERISCOPEHOST={{{get . "PERISCOPE_HOST_ADDRESS"}}}"
+            - "SERVICEDEPENDENCIES_PERISCOPEHOST={{{get . "PERISCOPE_HOST"}}}"
             - "SERVICEDEPENDENCIES_PERISCOPEPORT={{{get . "PERISCOPE_PORT"}}}"
             - "SERVICEDEPENDENCIES_CLUSTERHEALTHHOST=localhost"
             - "SERVICEDEPENDENCIES_CLUSTERHEALTHPORT={{{get . "DISTROX_API_HEALTHZ_PORT"}}}"
             - TELEMETRY_SERVICE_NAME=DistroxApi
+            - DEBUG={{{get . "DISTROX_API_DEBUG"}}}
         {{{- if get . "DISTROX_API_TARGET_PATH"}}}
         volumes:
         - {{{get . "DISTROX_API_TARGET_PATH"}}}/dependency-hard-links:/thunderhead-distrox-api-service/lib
@@ -23,6 +24,7 @@
             - traefik.backend=distrox-api-backend
             - traefik.frontend.priority=10
         ports:
+            - {{{get . "DISTROX_API_DEBUG_PORT"}}}:5005
             - 8988:8982
             - {{{get . "DISTROX_API_HEALTHZ_PORT"}}}:8983
         networks:

--- a/templates/compose-environments2-api.tmpl
+++ b/templates/compose-environments2-api.tmpl
@@ -12,6 +12,7 @@
             - "SERVICEDEPENDENCIES_FMSHOST={{{get . "FREEIPA_HOST"}}}"
             - "SERVICEDEPENDENCIES_FMSPORT={{{get . "FREEIPA_PORT"}}}"
             - TELEMETRY_SERVICE_NAME=Environments2Api
+            - DEBUG={{{get . "ENVIRONMENTS2_DEBUG"}}}
         {{{- if get . "ENVIRONMENTS2_API_TARGET_PATH"}}}
         volumes:
         - {{{get . "ENVIRONMENTS2_API_TARGET_PATH"}}}/dependency-hard-links:/thunderhead-environments2-api-service/lib
@@ -23,6 +24,7 @@
             - traefik.backend=environments2-api-backend
             - traefik.frontend.priority=10
         ports:
+            - {{{get . "ENVIRONMENTS2_DEBUG_PORT"}}}:5005
             - 8984:8982
             - {{{get . "ENVIRONMENTS2_API_HEALTHZ_PORT"}}}:8983
         networks:


### PR DESCRIPTION
So far debugging of CB public endpoints' code was not resolved. The public endpoint services however are provisioned for the usage of debug flag and debug port.
This is now introduced in CBD.

There were wrongly configured hosts (cb and autoscale) in public services docker containers, this is also going to be fixed.