### PR TITLE
CB-11544 Updated CDPCP container versions to 1.0.0-b3470

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,8 @@ update-container-versions-cdpcp:
 	sed -i "0,/DOCKER_TAG_ENVIRONMENTS2_API/ s/DOCKER_TAG_ENVIRONMENTS2_API .*/DOCKER_TAG_ENVIRONMENTS2_API $(CDPCP_VERSION)/" include/cloudbreak.bash
 	sed -i "0,/DOCKER_TAG_DATALAKE_API/ s/DOCKER_TAG_DATALAKE_API .*/DOCKER_TAG_DATALAKE_API $(CDPCP_VERSION)/" include/cloudbreak.bash
 	sed -i "0,/DOCKER_TAG_DISTROX_API/ s/DOCKER_TAG_DISTROX_API .*/DOCKER_TAG_DISTROX_API $(CDPCP_VERSION)/" include/cloudbreak.bash
-
+	sed -i "0,/DOCKER_TAG_AUDIT/ s/DOCKER_TAG_AUDIT .*/DOCKER_TAG_AUDIT $(CDPCP_VERSION)/" include/cloudbreak.bash
+	sed -i "0,/DOCKER_TAG_DATALAKE_DR/ s/DOCKER_TAG_DATALAKE_DR .*/DOCKER_TAG_DATALAKE_DR $(CDPCP_VERSION)/" include/cloudbreak.bash
 
 push-container-versions: update-container-versions
 	git add include/cloudbreak.bash

--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -69,12 +69,12 @@ cloudbreak-conf-tags() {
     env-import DOCKER_TAG_FREEIPA 2.40.0-b108
     env-import DOCKER_TAG_ULUWATU 2.40.0-b108
 
-    env-import DOCKER_TAG_IDBMMS 1.0.0-b3063
-    env-import DOCKER_TAG_ENVIRONMENTS2_API 1.0.0-b3063
-    env-import DOCKER_TAG_DATALAKE_API 1.0.0-b3063
-    env-import DOCKER_TAG_DISTROX_API 1.0.0-b3063
-    env-import DOCKER_TAG_AUDIT 1.0.0-b3193
-    env-import DOCKER_TAG_DATALAKE_DR 1.0.0-b3073
+    env-import DOCKER_TAG_IDBMMS 1.0.0-b3470
+    env-import DOCKER_TAG_ENVIRONMENTS2_API 1.0.0-b3470
+    env-import DOCKER_TAG_DATALAKE_API 1.0.0-b3470
+    env-import DOCKER_TAG_DISTROX_API 1.0.0-b3470
+    env-import DOCKER_TAG_AUDIT 1.0.0-b3470
+    env-import DOCKER_TAG_DATALAKE_DR 1.0.0-b3470
 
     env-import DOCKER_TAG_POSTGRES 9.6.16-alpine
     env-import DOCKER_TAG_CBD_SMARTSENSE 0.13.4


### PR DESCRIPTION
Update all Thunderhead dependencies to version 1.0.0-b3470.