### PR TITLE
CB-11152 Updated CDPCP container versions to 1.0.0-b3518

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -69,12 +69,12 @@ cloudbreak-conf-tags() {
     env-import DOCKER_TAG_FREEIPA 2.41.0-b9
     env-import DOCKER_TAG_ULUWATU 2.41.0-b9
 
-    env-import DOCKER_TAG_IDBMMS 1.0.0-b3470
-    env-import DOCKER_TAG_ENVIRONMENTS2_API 1.0.0-b3470
-    env-import DOCKER_TAG_DATALAKE_API 1.0.0-b3470
-    env-import DOCKER_TAG_DISTROX_API 1.0.0-b3470
-    env-import DOCKER_TAG_AUDIT 1.0.0-b3470
-    env-import DOCKER_TAG_DATALAKE_DR 1.0.0-b3470
+    env-import DOCKER_TAG_IDBMMS 1.0.0-b3518
+    env-import DOCKER_TAG_ENVIRONMENTS2_API 1.0.0-b3518
+    env-import DOCKER_TAG_DATALAKE_API 1.0.0-b3518
+    env-import DOCKER_TAG_DISTROX_API 1.0.0-b3518
+    env-import DOCKER_TAG_AUDIT 1.0.0-b3518
+    env-import DOCKER_TAG_DATALAKE_DR 1.0.0-b3518
 
     env-import DOCKER_TAG_POSTGRES 9.6.16-alpine
     env-import DOCKER_TAG_CBD_SMARTSENSE 0.13.4


### PR DESCRIPTION
Update all Thunderhead dependencies to version 1.0.0-b3518.