### PR TITLE
CB-11729 Traefik shall route iam calls to thunderhead mock. The reaso…

### DIFF
--- a/templates/compose-thunderhead-mock.tmpl
+++ b/templates/compose-thunderhead-mock.tmpl
@@ -14,7 +14,7 @@
         - "{{{get . "UMS_PORT"}}}:8982"
         labels:
         - traefik.frontend.priority=100
-        - traefik.frontend.rule=PathPrefix:/oidc,/idp,/thunderhead
+        - traefik.frontend.rule=PathPrefix:/iam,/oidc,/idp,/thunderhead
         - traefik.port=8080
         - traefik.backend=thunderhead-backend
         deploy:


### PR DESCRIPTION
…n for this is that we don't have real UMS in our test environment, and iam calls needs to be mocked by our mock-thunderhead service.