### PR TITLE
CB-12176 Add /iam to thunderhead-api-frontend.routes

### DIFF
--- a/templates/traefik.toml.tmpl
+++ b/templates/traefik.toml.tmpl
@@ -121,7 +121,7 @@
     [frontends.thunderhead-api-frontend]
     backend = "thunderhead-api"
         [frontends.thunderhead-api-frontend.routes.frontendrule]
-        rule = "PathPrefix:/auth,/oidc,/idp,/thunderhead"
+        rule = "PathPrefix:/auth,/oidc,/idp,/thunderhead,/iam"
         priority = 100
 {{{- end}}}
 {{{- if isLocal . "cluster-proxy"}}}


### PR DESCRIPTION
In order to mock IAM calls when running thunderhead-mock locally.