### PR TITLE
CB-11989 RDS: Upgrade cloudbreak PostgreSQL from v9 to v13

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -76,7 +76,7 @@ cloudbreak-conf-tags() {
     env-import DOCKER_TAG_AUDIT 1.0.0-b3944
     env-import DOCKER_TAG_DATALAKE_DR 1.0.0-b3944
 
-    env-import DOCKER_TAG_POSTGRES 9.6.16-alpine
+    env-import DOCKER_TAG_POSTGRES 13.2-alpine
     env-import DOCKER_TAG_CBD_SMARTSENSE 0.13.4
     env-import DOCKER_TAG_CLUSTER_PROXY 1.0.0-b40
     env-import DOCKER_TAG_CLUSTER_PROXY_HEALTH_CHECK_WORKER 1.0.0-b40

--- a/templates/compose-main.tmpl
+++ b/templates/compose-main.tmpl
@@ -33,6 +33,8 @@ services:
             - "5432:5432"
         volumes:
             - "{{{get . "COMMON_DB_VOL"}}}:/var/lib/postgresql/data"
+        environment:
+            - POSTGRES_HOST_AUTH_METHOD=trust
         networks:
         - {{{get . "DOCKER_NETWORK_NAME"}}}
         logging:
@@ -41,7 +43,7 @@ services:
                 max-file: "5"
         image: postgres:{{{get . "DOCKER_TAG_POSTGRES"}}}
         entrypoint: ["/bin/bash"]
-        command: -c 'cd /var/lib/postgresql; touch .ash_history .psql_history; chown -R postgres:postgres /var/lib/postgresql; (/docker-entrypoint.sh postgres -c max_connections=300 -c shared_preload_libraries='pg_stat_statements') & PGPID="$$!"; echo "PGPID $$PGPID"; trap "kill $$PGPID; wait $$PGPID" SIGINT SIGTERM; cd /var/lib/postgresql; (tail -f .*history) & wait "$$PGPID"'
+        command: -c 'cd /var/lib/postgresql; touch .ash_history .psql_history; chown -R postgres:postgres /var/lib/postgresql; (/usr/local/bin/docker-entrypoint.sh postgres -c max_connections=300 -c shared_preload_libraries='pg_stat_statements') & PGPID="$$!"; echo "PGPID $$PGPID"; trap "kill $$PGPID; wait $$PGPID" SIGINT SIGTERM; cd /var/lib/postgresql; (tail -f .*history) & wait "$$PGPID"'
 
     vault:
         labels:


### PR DESCRIPTION
v13 is not compatible with v9.

If you don't want to preserve your local data then just remove the cbreak_common volume with the `cbd delete` or the `docker volume rm cbreak_common` command.
If you want preserve your local dev database please follow these steps:
```
docker kill + stop the services in Idea
cbd startdb
docker ps -> check the postgres version, should be 9.6.16-alpine
docker exec -it -u postgres cbreak_commondb_1  pg_dumpall > dbdumpfile
save the vault keys from your Profile (VAULT_ROOT_TOKEN, VAULT_UNSEAL_KEYS)
cbd kill
docker volume rm cbreak_common
  
upgrade your cbd

cbd regenerate
cbd startdb
docker ps -> check the postgres version, should be 13.2-alpine
docker logs cbreak_commondb_1 -> check that the db started
check that the db is empty ('docker exec -itu postgres cbreak_commondb_1  psql -d cbdb' or similar should fail with message that the db does not exist)
cat dbdumpfile | docker exec -i -u postgres cbreak_commondb_1  psql -d postgres
cbd kill

restore vault keys in your Profile
cbd start
```
Local cb-2.9 database shouldn't be affected because the volume name is different ('common' instead of 'cbreak_common')
