### PR TITLE
CB-12709 Put WorkloadIam container creation behind a flag

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -288,6 +288,7 @@ cloudbreak-conf-defaults() {
     env-import IDBMMS_URL $(service-url idbmms "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "" "8990" "8982")
     env-import IDBMMS_HOST $(host-from-url "$IDBMMS_URL")
     env-import WORKLOADIAM_URL $(service-url workloadiam "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "" "8996" "8982")
+    env-import WORKLOADIAM_ENABLED false
     env-import WORKLOADIAM_HOST $(host-from-url "$WORKLOADIAM_URL")
     env-import ENVIRONMENTS2_API_URL $(service-url environments2-api "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "http://" "8984" "8982")
     env-import ENVIRONMENTS2_DEBUG false

--- a/include/env.bash
+++ b/include/env.bash
@@ -208,6 +208,7 @@ WORKLOADIAM_DB_ENV_PASS - Password for the WorkloadIam database authentication
 WORKLOADIAM_DB_ENV_USER - User for the WorkloadIam database authentication
 WORKLOADIAM_DB_PORT_5432_TCP_ADDR - Address of the WorkloadIam database
 WORKLOADIAM_DB_PORT_5432_TCP_PORT - Port number of the WorkloadIam database
+WORKLOADIAM_ENABLED - Start WorkloadIam container (default: false)
 PROXY_PORT - Proxy port
 PROXY_USER - Proxy user (basic auth)
 PROXY_PASSWORD - Proxy password (basic auth)

--- a/templates/compose-main.tmpl
+++ b/templates/compose-main.tmpl
@@ -136,7 +136,9 @@ services:
 {{{- block "redbeams" .}}}{{{end}}}
 {{{- block "freeipa" .}}}{{{end}}}
 {{{- block "idbmms" .}}}{{{end}}}
+{{{- if eq (get . "WORKLOADIAM_ENABLED") "true" }}}
 {{{- block "workloadiam" .}}}{{{end}}}
+{{{- end}}}
 {{{- block "environments2-api" .}}}{{{end}}}
 {{{- block "datalake-api" .}}}{{{end}}}
 {{{- block "distrox-api" .}}}{{{end}}}


### PR DESCRIPTION
Follow-up to #730. The thunderhead service WorkloadIam used to be always started so far. Since this service is non-essential for everyday development via CBD (unless testing some specific user-sync use cases that need WorkloadIam), the startup of WorkloadIam is made optional here. In particular, CBD service `workloadiam` / Docker container `cbreak_workloadiam_1` will only be started if the new `Profile` setting `WORKLOADIAM_ENABLED` is set to `true`. This flag defaults to `false`, so omitting the setting in `Profile` has the same effect as including the following statement:

```
export WORKLOADIAM_ENABLED=false
```

To enable WorkloadIam container creation, add the following to your CBD `Profile`:

```
export WORKLOADIAM_ENABLED=true
```

Irrespective of the value of `WORKLOADIAM_ENABLED`, Environments2Api will always receive the appropriate environment variables for its WorkloadIam connectivity dependency. Please note that these settings will be effectively invalid if WorkloadIam is not running, so any CLI invocations relying on the availability of WorkloadIam will fail in such cases.