### PR TITLE
Adding an extra debug line to help user find problems if they have mu…

### DIFF
--- a/include/deployer.bash
+++ b/include/deployer.bash
@@ -274,6 +274,9 @@ init-profile() {
 
     if [ -f $CBD_PROFILE ]; then
         debug "Use existing profile: $CBD_PROFILE"
+        if [[ "$CBD_PROFILE" != *\/* ]]; then
+          debug "$CBD_PROFILE file will be searched in your $PATH not just the current directory"
+        fi
         module-load "$CBD_PROFILE"
     fi
 


### PR DESCRIPTION
…ltiple Profile files

1. Recently we encountered a unique problem when Profile file was present both in the current directory and /usr/local/bin.
2. Upon reading bash documentation it was clear that source just does not use the current directory if the sourcing filename does not have a forward slash, instead it will search the entire path.
3. It seems it is difficult to fix such problems, so adding a debug line to help the user understand that what they think is happening is not what is happening.

Locally built, installed and tested it.