### PR TITLE
CB-14041: Fix cbd build procedure from scratch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ brew install go
 ```
 Export GOPATH and add to PATH the $GOPATH/bin directory:
 
-Get cloudbreak-deployer project with GO:
+Get cloudbreak-deployer project and dependencies with GO:
 ```
+export GO111MODULE=off
 go get -d github.com/hortonworks/cloudbreak-deployer
+go get -u github.com/jteeuwen/go-bindata/...
 ``` 
 
 Development process happens on separate branches. Open a pull-request to contribute your changes.


### PR DESCRIPTION
When building cbd from scratch with go 1.11 or later, modules must
either be used or the module must be disabled. This procedure change
disables modules so the build works from a fresh checkout.

This was manually tested.