### PR TITLE
CB-12982: Check if docker is running with a ps command.

### DIFF
--- a/include/compose.bash
+++ b/include/compose.bash
@@ -43,6 +43,7 @@ compose-init() {
 }
 
 dockerCompose() {
+    docker ps 1>/dev/null || _exit 1
     debug "docker-compose -p ${CB_COMPOSE_PROJECT} $@"
     docker-compose --compatibility -p ${CB_COMPOSE_PROJECT} "$@"
 }


### PR DESCRIPTION
Closes [CB-12982](https://jira.cloudera.com/browse/CB-12982).

Check if Docker daemon is running by doing a ps before running `docker-compose` commands.

Changes the output from this:
```
$ cbd ps
[43686] Failed to execute script docker-compose
Traceback (most recent call last):
  File "site-packages/urllib3/connectionpool.py", line 677, in urlopen
  File "site-packages/urllib3/connectionpool.py", line 392, in _make_request
  File "http/client.py", line 1252, in request
  File "http/client.py", line 1298, in _send_request
  File "http/client.py", line 1247, in endheaders
  File "http/client.py", line 1026, in _send_output
  File "http/client.py", line 966, in send
  File "site-packages/docker/transport/unixconn.py", line 43, in connect
ConnectionRefusedError: [Errno 61] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "site-packages/requests/adapters.py", line 449, in send
  File "site-packages/urllib3/connectionpool.py", line 727, in urlopen
  File "site-packages/urllib3/util/retry.py", line 403, in increment
  File "site-packages/urllib3/packages/six.py", line 734, in reraise
  File "site-packages/urllib3/connectionpool.py", line 677, in urlopen
  File "site-packages/urllib3/connectionpool.py", line 392, in _make_request
  File "http/client.py", line 1252, in request
  File "http/client.py", line 1298, in _send_request
  File "http/client.py", line 1247, in endheaders
  File "http/client.py", line 1026, in _send_output
  File "http/client.py", line 966, in send
  File "site-packages/docker/transport/unixconn.py", line 43, in connect
urllib3.exceptions.ProtocolError: ('Connection aborted.', ConnectionRefusedError(61, 'Connection refused'))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "site-packages/docker/api/client.py", line 205, in _retrieve_server_version
  File "site-packages/docker/api/daemon.py", line 181, in version
  File "site-packages/docker/utils/decorators.py", line 46, in inner
  File "site-packages/docker/api/client.py", line 228, in _get
  File "site-packages/requests/sessions.py", line 543, in get
  File "site-packages/requests/sessions.py", line 530, in request
  File "site-packages/requests/sessions.py", line 643, in send
  File "site-packages/requests/adapters.py", line 498, in send
requests.exceptions.ConnectionError: ('Connection aborted.', ConnectionRefusedError(61, 'Connection refused'))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "docker-compose", line 3, in <module>
  File "compose/cli/main.py", line 67, in main
  File "compose/cli/main.py", line 123, in perform_command
  File "compose/cli/command.py", line 69, in project_from_options
  File "compose/cli/command.py", line 132, in get_project
  File "compose/cli/docker_client.py", line 43, in get_client
  File "compose/cli/docker_client.py", line 170, in docker_client
  File "site-packages/docker/api/client.py", line 188, in __init__
  File "site-packages/docker/api/client.py", line 213, in _retrieve_server_version
docker.errors.DockerException: Error while fetching server API version: ('Connection aborted.', ConnectionRefusedError(61, 'Connection refused'))
2021/09/09 14:57:13 exit status 255
```

To this:
```
$ cbd ps
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
2021/09/09 14:56:17 exit status 1
```