### PR TITLE
CB-14675 Fix Makefile target install for Linux deployments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,9 @@ deps: deps-bindata ## Installs required cli tools (only needed for new envs)
 bindata: deps
 	go-bindata include templates .deps/bin
 
-install: build ## Installs OS specific binary into: /usr/local/bin
-	install build/$(shell uname -s)/$(BINARYNAME) /usr/local/bin
+install: build ## Installs OS specific binary into: /usr/local/bin and ~/.local/bin
+	install build/$(shell uname -s)/$(BINARYNAME) /usr/local/bin || true
+	install build/$(shell uname -s)/$(BINARYNAME) ~/.local/bin || true
 
 prepare-release:
 	rm -rf release && mkdir release


### PR DESCRIPTION
* Fix `Makefile` target `install` to succeed in Linux deployments. Whereas Mac permits installing binaries to directory `/usr/local/bin` even for non-`root` users, Linux prohibits this. In order to avoid having to run the command as `root`, the compiled binary will be also copied to directory `~/.local/bin` that usually exists in Linux in the user home.
  * `~/.local/bin` is not explicitly created. This is the user's responsibility, and so is adding that directory to `PATH`.
  * Copy operations will be attempted for both locations, no matter which OS is being used. A failure of either copy will not make the target `install` fail.