### PR TITLE
CDPSDX-3219: Added Regex to logic for checking if service is local to avoid mismatch of substrings.

### DIFF
--- a/compose.go
+++ b/compose.go
@@ -71,7 +71,7 @@ func insertIntoTemplate(t *template.Template, service string) {
 }
 
 func insertIntoTemplateIfNotLocal(t *template.Template, localDevList string, service string) {
-	if !strings.Contains(localDevList, service) {
+	if !checkIfServiceInLocal(service, localDevList) {
 		insertIntoTemplate(t, service)
 	}
 }

--- a/compose_test.go
+++ b/compose_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 var inputVars = `
-export CB_LOCAL_DEV_LIST=cloudbreak
+export CB_LOCAL_DEV_LIST=cloudbreak,datalake-dr
 export THUNDERHEAD_MOCK_BIND_PORT=10080
 export THUNDERHEAD_MOCK_VOLUME_CONTAINER=/tmp/null
 export THUNDERHEAD_MOCK_VOLUME_HOST=/dev/null
@@ -67,8 +67,12 @@ func TestComposeGenerationWithoutDps(t *testing.T) {
 	out := catchStdInStdOut(t, inputVars, func() {
 		GenerateComposeYaml([]string{})
 	})
+
+	// Matches the services appearing in the compose.yml file by matching from the beginning of any
+	// string, ignoring any whitespace that may be present, and matching the service name 
+	// followed by a ':'.
 	should := []string{`(?m)^\s*periscope:`, `(?m)^\s*cluster-proxy:`, `(?m)^\s*datalake:`, `(?m)^\s*redbeams:`}
-	shouldnt := []string{`(?m)^\s*cloudbreak:`, `(?m)^\s*core-gateway:`}
+	shouldnt := []string{`(?m)^\s*cloudbreak:`, `(?m)^\s*core-gateway:`, `(?m)^\s*datalake-dr:`}
 	for _, s := range should {
 		re := regexp.MustCompile(s)
 		if res := re.FindString(out); len(res) == 0 {
@@ -88,7 +92,7 @@ func TestComposeGenerationWithDps(t *testing.T) {
 		GenerateComposeYaml([]string{})
 	})
 	should := []string{`(?m)^\s*periscope:`, `(?m)^\s*datalake:`, `(?m)^\s*redbeams:`, `(?m)^\s*cluster-proxy:`}
-	shouldnt := []string{`(?m)^\s*cloudbreak:`}
+	shouldnt := []string{`(?m)^\s*cloudbreak:`, `(?m)^\s*datalake-dr:`}
 	for _, s := range should {
 		re := regexp.MustCompile(s)
 		if res := re.FindString(out); len(res) == 0 {

--- a/functions.go
+++ b/functions.go
@@ -82,7 +82,8 @@ func Checksum(args []string) {
 
 func ServiceURL(args []string) {
 	serviceName, bridgeAddress, localDevList, protocol, localDevPort, servicePort := unpackServiceURLArgs(args)
-	if strings.Contains(localDevList, serviceName) {
+	
+	if checkIfServiceInLocal(serviceName, localDevList) {
 		printServiceURL(bridgeAddress, protocol, localDevPort)
 	} else {
 		printServiceURL(serviceName, protocol, servicePort)
@@ -99,6 +100,18 @@ func printServiceURL(serviceName string, protocol string, port string) {
 
 func unpackServiceURLArgs(args []string) (string, string, string, string, string, string) {
 	return args[0], args[1], args[2], args[3], args[4], args[5]
+}
+
+// Checks if the service is in the local dev string by assuming the local dev string
+// is comma-separated and matching against the 4 possible ways a service may be present:
+// 		- "service"
+// 		- "other_services,service"
+// 		- "service,other_services"
+// 		- "other_services1,service,other_services2"
+// With any number of whitespace in between the services and the commas.
+func checkIfServiceInLocal(serviceName string, localDevList string) bool {
+	matched, _ := regexp.MatchString(`(,|^)\s*` + serviceName + `\s*(,|$)`, localDevList)
+	return matched
 }
 
 type caddyFileParams struct {

--- a/functions_test.go
+++ b/functions_test.go
@@ -12,6 +12,10 @@ func TestServiceURL(t *testing.T) {
 	}{
 		{[]string{"cloudbreak", "bridge.address", "", "http://", "9091", "8080"}, "http://cloudbreak:8080"},
 		{[]string{"cloudbreak", "bridge.address", "cloudbreak", "http://", "9091", "8080"}, "http://bridge.address:9091"},
+		{[]string{"datalake", "bridge.address", "cloudbreak,datalake,environment", "http://", "8086", "8080"}, "http://bridge.address:8086"},
+		{[]string{"datalake", "bridge.address", "cloudbreak,datalake-api,datalake-dr,environment", "http://", "8086", "8080"}, "http://datalake:8080"},
+		{[]string{"datalake", "bridge.address", "datalake,environment", "http://", "8086", "8080"}, "http://bridge.address:8086"},
+		{[]string{"datalake", "bridge.address", "cloudbreak,datalake", "http://", "8086", "8080"}, "http://bridge.address:8086"},
 	}
 
 	for _, c := range testCases {

--- a/traefik.go
+++ b/traefik.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 	"text/template"
 )
 
@@ -36,7 +35,7 @@ func GenerateTraefikToml(args []string) {
 		}
 		t := template.Must(template.New("traefik").Delims("{{{", "}}}").Funcs(template.FuncMap{
 			"isLocal": func(p traefikTomlParams, service string) bool {
-				return strings.Contains(p.LocalDevList, service)
+				return checkIfServiceInLocal(service, p.LocalDevList)
 			},
 		}).Parse(string(tmpl)))
 		t.Execute(os.Stdout, params)

--- a/traefik_test.go
+++ b/traefik_test.go
@@ -41,10 +41,6 @@ var expectedMulti string = `[file]
         [backends.cloudbreak.servers]
             [backends.cloudbreak.servers.server0]
             url = "cloudbreakURL"
-    [backends.datalake]
-        [backends.datalake.servers]
-            [backends.datalake.servers.server0]
-            url = "datalakeURL"
     [backends.environment]
         [backends.environment.servers]
             [backends.environment.servers.server0]
@@ -61,17 +57,16 @@ var expectedMulti string = `[file]
         [backends.freeipa.servers]
             [backends.freeipa.servers.server0]
             url = "freeIpaURL"
+    [backends.datalake-api]
+        [backends.datalake-api.servers]
+            [backends.datalake-api.servers.server0]
+            url = "datalakeApiURL"
 
 [frontends]
     [frontends.cloudbreak-frontend]
     backend = "cloudbreak"
         [frontends.cloudbreak-frontend.routes.frontendrule]
         rule = "PathPrefix:/cb/"
-        priority = 100
-    [frontends.datalake-frontend]
-    backend = "datalake"
-        [frontends.datalake-frontend.routes.frontendrule]
-        rule = "PathPrefix:/dl/"
         priority = 100
     [frontends.environment-frontend]
     backend = "environment"
@@ -92,6 +87,11 @@ var expectedMulti string = `[file]
     backend = "freeipa"
         [frontends.freeipa-frontend.routes.frontendrule]
         rule = "PathPrefix:/freeipa/"
+        priority = 100
+    [frontends.datalake-api-frontend]
+    backend = "datalake-api"
+        [frontends.datalake-api-frontend.routes.frontendrule]
+        rule = "PathPrefix:/api/v1/datalake/"
         priority = 100
 
 # Tracing definition
@@ -129,7 +129,7 @@ func TestCloudbreakLocalService(t *testing.T) {
 
 func TestMultiLocalService(t *testing.T) {
 	out := catchStdOut(t, func() {
-		GenerateTraefikToml([]string{"cloudbreakURL", "periscopeURL", "datalakeURL", "environmentURL", "redbeamsURL", "freeIpaURL", "thunderheadURL", "clusterProxyURL", "environments2ApiURL", "datalakeApiURL", "distroxApiURL", "JAEGER_HOST", "cloudbreak,periscope,datalake,environment,redbeams,freeipa"})
+		GenerateTraefikToml([]string{"cloudbreakURL", "periscopeURL", "datalakeURL", "environmentURL", "redbeamsURL", "freeIpaURL", "thunderheadURL", "clusterProxyURL", "environments2ApiURL", "datalakeApiURL", "distroxApiURL", "JAEGER_HOST", "cloudbreak,periscope,datalake-api,environment,redbeams,freeipa"})
 	})
 	if out != expectedMulti {
 		t.Errorf("If services were defined as local-dev, traefik.toml should contain the defined services. out:'%s'", out)


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CDPSDX-3219

I specifically faced this issue when trying to run the **datalake-dr** service locally resulting in CBD not deploying the **datalake** container.

I basically just added a Regex which matches the only 4 possible cases I could think of where a service is truly in the local list:

1. "CB_LOCAL_DEV_LIST=_service_"
2. "CB_LOCAL_DEV_LIST=other_services,_service_"
3. "CB_LOCAL_DEV_LIST=_service_,other_services"
4. "CB_LOCAL_DEV_LIST=other_services1,_service_,other_services2"

Where each of those cases can have any number of spaces before or after the service names.

I added this logic to:

- Logic that generates service URLs
- Logic that generates the docker-compose file
- Logic that generates the traefik file

In case this is expected behavior, please let me know!