### PR TITLE
CDPSDX-3221: Updated Thunderhead image tags to a more recent build.

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -71,13 +71,13 @@ cloudbreak-conf-tags() {
     env-import DOCKER_TAG_FREEIPA 2.50.0-b33
     env-import DOCKER_TAG_ULUWATU 2.50.0-b33
 
-    env-import DOCKER_TAG_IDBMMS 1.0.0-b5209
-    env-import DOCKER_TAG_WORKLOADIAM 1.0.0-b5209
-    env-import DOCKER_TAG_ENVIRONMENTS2_API 1.0.0-b5209
-    env-import DOCKER_TAG_DATALAKE_API 1.0.0-b5209
-    env-import DOCKER_TAG_DISTROX_API 1.0.0-b5209
-    env-import DOCKER_TAG_AUDIT 1.0.0-b5209
-    env-import DOCKER_TAG_DATALAKE_DR 1.0.0-b5209
+    env-import DOCKER_TAG_IDBMMS 1.0.0-b5294
+    env-import DOCKER_TAG_WORKLOADIAM 1.0.0-b5294
+    env-import DOCKER_TAG_ENVIRONMENTS2_API 1.0.0-b5294
+    env-import DOCKER_TAG_DATALAKE_API 1.0.0-b5294
+    env-import DOCKER_TAG_DISTROX_API 1.0.0-b5294
+    env-import DOCKER_TAG_AUDIT 1.0.0-b5294
+    env-import DOCKER_TAG_DATALAKE_DR 1.0.0-b5294
 
     env-import DOCKER_TAG_POSTGRES 13.2-alpine
     env-import DOCKER_TAG_CBD_SMARTSENSE 0.13.4


### PR DESCRIPTION
Related to Jira: https://jira.cloudera.com/browse/CDPSDX-3221 as this will help fix the Datalake-DR service on CBD.