### PR TITLE
CB-16674 added consumption to db-init scripts

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -152,6 +152,12 @@ cloudbreak-conf-db() {
     env-import PERISCOPE_DB_ENV_PASS ""
     env-import PERISCOPE_DB_ENV_SCHEMA "public"
     env-import PERISCOPE_HBM2DDL_STRATEGY "validate"
+    
+    env-import CONSUMPTION_DB_ENV_USER "postgres"
+    env-import CONSUMPTION_DB_ENV_DB "consumptiondb"
+    env-import CONSUMPTION_DB_ENV_PASS ""
+    env-import CONSUMPTION_DB_ENV_SCHEMA "public"
+    env-import CONSUMPTION_HBM2DDL_STRATEGY "validate"    
 
     env-import DATALAKE_DB_ENV_USER "postgres"
     env-import DATALAKE_DB_ENV_DB "datalakedb"


### PR DESCRIPTION
Error found by @biharitomi :
```
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'dataSource' defined in class path resource [com/sequenceiq/consumption/configuration/DatabaseConfig.class]: Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [javax.sql.DataSource]: Factory method 'dataSource' threw exception; nested exception is com.zaxxer.hikari.pool.HikariPool$PoolInitializationException: Failed to initialize pool: FATAL: database "consumptiondb" does not exist
```

Validated the changes, cbd now creates consumptiondb 🥇 