### PR TITLE
CDPSDX-3638: Expose mock DR service in thunderhead mock container.

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -379,6 +379,8 @@ cloudbreak-conf-defaults() {
         fi
     fi
 
+    env-import MOCK_DATALAKE_DR_PORT "8981"
+
     env-import UMS_PORT "8982"
 
     env-import SAAS_SDX_HOST $(service-url thunderhead-mock "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "" "" "")

--- a/templates/compose-thunderhead-mock.tmpl
+++ b/templates/compose-thunderhead-mock.tmpl
@@ -12,6 +12,7 @@
         ports:
         - "{{{get . "THUNDERHEAD_MOCK_BIND_PORT"}}}:8080"
         - "{{{get . "UMS_PORT"}}}:8982"
+        - "{{{get . "MOCK_DATALAKE_DR_PORT"}}}:8989"
         labels:
         - traefik.frontend.priority=100
         - traefik.frontend.rule=PathPrefix:/iam,/oidc,/idp,/thunderhead


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CDPSDX-3638

Very simple, this will allow us to run mock tests with datalake DR using CBD.