### PR TITLE
CDPSDX-3642: Add a new endpoint variable for the mock DR service which will be passed into the Datalake container.

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -363,6 +363,8 @@ cloudbreak-conf-defaults() {
     env-import ENVIRONMENT_EXPERIENCE_SCAN_ENABLED false
     env-import CONSUMPTION_ENABLED false
 
+    env-import MOCK_DATALAKE_DR_PORT "8981"
+
     if [[ "$THUNDERHEAD_MOCK" == "true" ]]; then
         env-import ULUWATU_FRONTEND_RULE "PathPrefix:/"
         env-import THUNDERHEAD_URL $(service-url thunderhead-mock "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "" "8080" "8080")
@@ -371,6 +373,7 @@ cloudbreak-conf-defaults() {
             env-import UMS_HOST $(service-url thunderhead-mock "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "" "" "")
         fi
         env-import CLUSTERDNS_HOST $(service-url thunderhead-mock "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "" "" "")
+        env-import MOCK_DATALAKE_DR_ENDPOINT $(service-url thunderhead-mock "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "" "8981" "${MOCK_DATALAKE_DR_PORT}") 
     else
         env-import GATEWAY_DEFAULT_REDIRECT_PATH "/cloud"
         env-import THUNDERHEAD_URL $(service-url thunderhead-api "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "" "8080" "10080")
@@ -378,8 +381,6 @@ cloudbreak-conf-defaults() {
             env-import UMS_HOST $(service-url thunderhead-api "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "" "" "")
         fi
     fi
-
-    env-import MOCK_DATALAKE_DR_PORT "8981"
 
     env-import UMS_PORT "8982"
 

--- a/templates/compose-datalake.tmpl
+++ b/templates/compose-datalake.tmpl
@@ -43,6 +43,7 @@
             - STATUSCHECKER_ENABLED={{{get . "DATALAKE_STATUSCHECKER_ENABLED"}}}
             - "ALTUS_DATALAKEDR_ENDPOINT={{{get . "DATALAKE_DR_ENDPOINT"}}}"
             - "ALTUS_DATALAKEDR_ENABLED={{{get . "DATALAKE_DR_ENABLED"}}}"
+            - "ALTUS_DATALAKEDR_MOCKENDPOINT={{{get . "MOCK_DATALAKE_DR_ENDPOINT"}}}"
         labels:
             - traefik.port=8080
             - traefik.frontend.rule=PathPrefix:/dl/

--- a/templates/compose-thunderhead-mock.tmpl
+++ b/templates/compose-thunderhead-mock.tmpl
@@ -12,7 +12,7 @@
         ports:
         - "{{{get . "THUNDERHEAD_MOCK_BIND_PORT"}}}:8080"
         - "{{{get . "UMS_PORT"}}}:8982"
-        - "{{{get . "MOCK_DATALAKE_DR_PORT"}}}:8989"
+        - "{{{get . "MOCK_DATALAKE_DR_PORT"}}}:8981"
         labels:
         - traefik.frontend.priority=100
         - traefik.frontend.rule=PathPrefix:/iam,/oidc,/idp,/thunderhead


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CDPSDX-3642

Objective of this is to pass in a new environment variable to the Datalake service which specifies the endpoint for the mock DR service.