### PR TITLE
CDPSDX-3648: Revert use of mock datalake dr endpoint in order to use a more simplified approach.

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -373,7 +373,6 @@ cloudbreak-conf-defaults() {
             env-import UMS_HOST $(service-url thunderhead-mock "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "" "" "")
         fi
         env-import CLUSTERDNS_HOST $(service-url thunderhead-mock "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "" "" "")
-        env-import MOCK_DATALAKE_DR_ENDPOINT $(service-url thunderhead-mock "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "" "8981" "${MOCK_DATALAKE_DR_PORT}") 
     else
         env-import GATEWAY_DEFAULT_REDIRECT_PATH "/cloud"
         env-import THUNDERHEAD_URL $(service-url thunderhead-api "$BRIDGE_ADDRESS" "$CB_LOCAL_DEV_LIST" "" "8080" "10080")

--- a/templates/compose-datalake.tmpl
+++ b/templates/compose-datalake.tmpl
@@ -43,7 +43,6 @@
             - STATUSCHECKER_ENABLED={{{get . "DATALAKE_STATUSCHECKER_ENABLED"}}}
             - "ALTUS_DATALAKEDR_ENDPOINT={{{get . "DATALAKE_DR_ENDPOINT"}}}"
             - "ALTUS_DATALAKEDR_ENABLED={{{get . "DATALAKE_DR_ENABLED"}}}"
-            - "ALTUS_DATALAKEDR_MOCKENDPOINT={{{get . "MOCK_DATALAKE_DR_ENDPOINT"}}}"
         labels:
             - traefik.port=8080
             - traefik.frontend.rule=PathPrefix:/dl/


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CDPSDX-3648