### PR TITLE
CB-18352: Updated Thunderhead container versions to b7581.

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -72,13 +72,13 @@ cloudbreak-conf-tags() {
     env-import DOCKER_TAG_FREEIPA 2.62.0-b62
     env-import DOCKER_TAG_ULUWATU 2.62.0-b62
 
-    env-import DOCKER_TAG_IDBMMS 1.0.0-b6159
-    env-import DOCKER_TAG_WORKLOADIAM 1.0.0-b6159
-    env-import DOCKER_TAG_ENVIRONMENTS2_API 1.0.0-b6159
-    env-import DOCKER_TAG_DATALAKE_API 1.0.0-b6159
-    env-import DOCKER_TAG_DISTROX_API 1.0.0-b6159
-    env-import DOCKER_TAG_AUDIT 1.0.0-b6159
-    env-import DOCKER_TAG_DATALAKE_DR 1.0.0-b6159
+    env-import DOCKER_TAG_IDBMMS 1.0.0-b7581
+    env-import DOCKER_TAG_WORKLOADIAM 1.0.0-b7581
+    env-import DOCKER_TAG_ENVIRONMENTS2_API 1.0.0-b7581
+    env-import DOCKER_TAG_DATALAKE_API 1.0.0-b7581
+    env-import DOCKER_TAG_DISTROX_API 1.0.0-b7581
+    env-import DOCKER_TAG_AUDIT 1.0.0-b7581
+    env-import DOCKER_TAG_DATALAKE_DR 1.0.0-b7581
 
     env-import DOCKER_TAG_POSTGRES 13.2-alpine
     env-import DOCKER_TAG_CBD_SMARTSENSE 0.13.4


### PR DESCRIPTION
Jira: https://jira.cloudera.com/browse/CB-18352