### PR TITLE
CB-18569 using new cdp gateway if using mow dev ums, increasing grpc …

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -279,6 +279,7 @@ cloudbreak-conf-defaults() {
 
     env-import CB_LOCAL_DEV_LIST ""
     env-import DPS_VERSION "latest"
+    env-import CDP_GW_VERSION "2.1.0-b228"
     env-import DPS_REPO ""
     env-import UMS_ENABLED "true"
     env-import THUNDERHEAD_MOCK "true"

--- a/templates/compose-core-gateway.tmpl
+++ b/templates/compose-core-gateway.tmpl
@@ -3,7 +3,11 @@
         {{{- if get . "DPS_REPO"}}}
         build: {{{get . "DPS_REPO"}}}/core-gateway
         {{{- end}}}
+        {{{- if eq (get . "UMS_HOST") "ums.thunderhead-dev.cloudera.com"}}}
+        image: docker-private.infra.cloudera.com/cloudera/cdp-gateway:{{{get . "CDP_GW_VERSION"}}}
+        {{{- else }}}
         image: docker-private.infra.cloudera.com/cloudera_thirdparty/dps-gateway:{{{get . "DPS_VERSION"}}}
+        {{{- end }}}
         # ports:
             # - {{{get . "PUBLIC_HTTP_PORT"}}}:3000
             # - {{{get . "PUBLIC_HTTPS_PORT"}}}:443
@@ -17,6 +21,9 @@
         - GATEWAY_UNAUTHENTICATED_PATHS=pathPrefix:/idp,pathPrefix:/oidc,pathPrefix:/thunderhead,pathPrefix:/thunderhead/auth,!pathPrefix:/thunderhead/api,pathPrefix:/core,!pathPrefix:/core/api,pathPrefix:/cloud/cb/info,pathPrefix:/cb/info,pathPrefix:/environmentservice/info,pathPrefix:/dl/info,pathPrefix:/freeipa/info
         - UMS_HOST={{{get . "UMS_HOST"}}}
         - GATEWAY_DEFAULT_REDIRECT_PATH={{{get . "GATEWAY_DEFAULT_REDIRECT_PATH"}}}
+        {{{- if eq (get . "UMS_HOST") "ums.thunderhead-dev.cloudera.com"}}}
+        - GRPC_TIMEOUT_MS=20000
+        {{{- end }}}
         - GATEWAY_REDIRECT_ENDPOINT_PATH=/thunderhead/auth/in
         deploy:
           resources:


### PR DESCRIPTION
…timeout to handle ums slowness

- somehow old dps-gateway cannot handle change of grpc timeout env variable so in case of real ums tests we will use new cdp gateway with increased grpc timeout to workaround ums slowness
- later I'll try our mock tests with new cdp gateway, if it works, then we can use cdp gateway everywhere