### PR TITLE
Update Cadence default version to the version being used in mow-dev/int/stage/prod.

### DIFF
--- a/include/cloudbreak.bash
+++ b/include/cloudbreak.bash
@@ -84,7 +84,7 @@ cloudbreak-conf-tags() {
     env-import DOCKER_TAG_CBD_SMARTSENSE 0.13.4
     env-import DOCKER_TAG_CLUSTER_PROXY 3.0.0-b59
     env-import DOCKER_TAG_CLUSTER_PROXY_HEALTH_CHECK_WORKER 3.0.0-b59
-    env-import DOCKER_TAG_CADENCE 0.11.0-auto-setup
+    env-import DOCKER_TAG_CADENCE 0.24.0-auto-setup
     env-import DOCKER_TAG_CADENCE_WEB 1.0.0-b24
 
     env-import DOCKER_IMAGE_THUNDERHEAD_MOCK docker-private.infra.cloudera.com/cloudera/cloudbreak-mock-thunderhead
@@ -397,6 +397,7 @@ cloudbreak-conf-defaults() {
 
     env-import CLUSTERPROXY_ENABLED "true"
 
+    env-import CADENCE_GRPC_PORT "7833"
     env-import CADENCE_FRONTEND_PORT "7933"
     env-import CADENCE_HISTORY_PORT "7934"
     env-import CADENCE_MATCHING_PORT "7935"

--- a/templates/compose-cadence.tmpl
+++ b/templates/compose-cadence.tmpl
@@ -2,6 +2,7 @@
     cadence:
         image: {{{get . "DOCKER_IMAGE_CADENCE"}}}:{{{get . "DOCKER_TAG_CADENCE"}}}
         ports:
+            - "{{{get . "CADENCE_GRPC_PORT"}}}:7833"
             - "{{{get . "CADENCE_FRONTEND_PORT"}}}:7933"
             - "{{{get . "CADENCE_HISTORY_PORT"}}}:7934"
             - "{{{get . "CADENCE_MATCHING_PORT"}}}:7935"


### PR DESCRIPTION
The version is very old, the new version also supports GRPC communication which is a new standard for our Thunderhead services, especially in FedRAMP.